### PR TITLE
Fix #384 - bin2llvmir: Be more strict when merging values

### DIFF
--- a/src/bin2llvmir/analyses/symbolic_tree.cpp
+++ b/src/bin2llvmir/analyses/symbolic_tree.cpp
@@ -413,8 +413,7 @@ void SymbolicTree::_simplifyNode()
 		*this = std::move(ops[0].ops[0]);
 	}
 	else if (match(*this, m_Load(m_Value(val), &load))
-			&& (isa<AllocaInst>(llvm_utils::skipCasts(load->getPointerOperand()))
-			|| isa<GlobalVariable>(llvm_utils::skipCasts(load->getPointerOperand()))))
+			&& isa<AllocaInst>(llvm_utils::skipCasts(load->getPointerOperand())))
 	{
 		*this = std::move(ops[0]);
 	}


### PR DESCRIPTION
This fixes the issues mentioned in #384. I merely removed the check that made load result and the load origin considered equivalent, this is definitely wrong. Maybe some other checks here are also wrong, I can't really tell.