### PR TITLE
Parallelize compilation of YARA rules during installation (#540)

### DIFF
--- a/support/install-yara.py
+++ b/support/install-yara.py
@@ -89,6 +89,9 @@ def compile_yara_files(yarac, install_dir):
         for filename in fnmatch.filter(filenames, '*.yara'):
             inputs.append(os.path.join(root, filename))
 
+    if not inputs:
+        return
+
     stdout_lock = threading.Lock()
     with multiprocessing.pool.ThreadPool() as pool:
         args = [

--- a/support/install-yara.py
+++ b/support/install-yara.py
@@ -9,11 +9,13 @@ Usage: install-yara.py yarac-path install-path yara-patterns-path compile
 """
 
 import fnmatch
+import multiprocessing.pool
 import os
 import pathlib
 import shutil
 import subprocess
 import sys
+import threading
 
 
 def print_help():
@@ -59,7 +61,25 @@ def copy_yara_patterns(yara_patterns_dir, install_dir):
                 shutil.copy(input, output)
 
 
-def compile_yara(yarac, install_dir):
+def compile_yara_file(input_file, yarac, install_dir, stdout_lock):
+    """ Compile the given .yara file in the given installation directory using
+    the provided YARAC program into a *.yarac file.
+    Remove the source *.yara file.
+    """
+    with stdout_lock:
+        print('-- Compiling:', input_file)
+
+    output_file = str(pathlib.Path(input_file).with_suffix('.yarac'))
+    cmd = [yarac, '-w', input_file, output_file]
+    ret = subprocess.call(cmd)
+    if ret != 0:
+        print('Error: yarac failed during compilation of file', input_file, file=sys.stderr)
+        sys.exit(1)
+
+    os.remove(input_file)
+
+
+def compile_yara_files(yarac, install_dir):
     """ Compile all *.yara files in the given installation directory using the
     provided YARAC program into *.yarac files.
     Remove the source *.yara files.
@@ -69,18 +89,12 @@ def compile_yara(yarac, install_dir):
         for filename in fnmatch.filter(filenames, '*.yara'):
             inputs.append(os.path.join(root, filename))
 
-    for i in inputs:
-        fn = pathlib.Path(i)
-        o = fn.with_suffix('.yarac')
-
-        print('-- Compiling:', i)
-        cmd = [yarac, '-w'] + [i] + [str(o)]
-        ret = subprocess.call(cmd)
-        if ret != 0:
-            print('Error: yarac failed during compilation of file ', path)
-            exit(1)
-
-        os.remove(i)
+    stdout_lock = threading.Lock()
+    with multiprocessing.pool.ThreadPool() as pool:
+        args = [
+            (input_file, yarac, install_dir, stdout_lock) for input_file in inputs
+        ]
+        pool.starmap(compile_yara_file, args)
 
 
 def main():
@@ -88,7 +102,7 @@ def main():
     copy_yara_patterns(yara_patterns_dir, install_dir)
 
     if compile:
-        compile_yara(yarac, install_dir)
+        compile_yara_files(yarac, install_dir)
 
     sys.exit(0)
 


### PR DESCRIPTION
When you run cmake with `-DRETDEC_COMPILE_YARA=ON` (the default), YARA rules that RetDec uses are compiled during the installation step, which makes decompilations run faster (no need to compile them on the fly during each decompilation). The issue is that YARA rules are compiled sequentially, which takes around 50 seconds to compile them on my machine.

This PR parallelizes their compilation by using all available cores. Now, the compilation takes around 10 seconds on my machine (Intel Xeon E5-1650 @ 3.60GHz, 6 cores with HT = 12 threads).

I have implemented the easy way (using all available cores) as I was unable to find a portable solution of obtaining the value of `-j` (when using `make`) or `/m` (when using Visual Studio).

Implements #540.
