### PR TITLE
Warning fixes

### DIFF
--- a/include/retdec/fileformat-libdwarf-interface/dwarfdump.add
+++ b/include/retdec/fileformat-libdwarf-interface/dwarfdump.add
@@ -17,7 +17,7 @@
                 /* not a 64-bit obj either! */
                 /* dwarfdump is quiet when not an object */
 // with
-            	process_one_file(elf, file_name, archive, &config_file_data);
+                process_one_file(elf, file_name, archive, &config_file_data);
 // or just always call process_one_file.
 
 // Add bin-interface to process_one_file().

--- a/include/retdec/fileformat/types/resource_table/bitmap_image.h
+++ b/include/retdec/fileformat/types/resource_table/bitmap_image.h
@@ -103,4 +103,3 @@ class BitmapImage
 } // namespace retdec
 
 #endif
-

--- a/src/capstone2llvmir/arm64/arm64_init.cpp
+++ b/src/capstone2llvmir/arm64/arm64_init.cpp
@@ -608,9 +608,9 @@ void Capstone2LlvmIrTranslatorArm64_impl::initializeRegNameMap()
 			{A64SysReg_ICH_ELSR_EL2, "ich_elsr_el2"},
 
 			// PSTATE - those are probably not registers
-	 		{ARM64_PSTATE_SPSEL, "spsel"},
-	 		{ARM64_PSTATE_DAIFSET, "daifset"},
-	 		{ARM64_PSTATE_DAIFCLR, "daifclr"},
+			{ARM64_PSTATE_SPSEL, "spsel"},
+			{ARM64_PSTATE_DAIFSET, "daifset"},
+			{ARM64_PSTATE_DAIFCLR, "daifclr"},
 	};
 
 	_reg2name = std::move(r2n);

--- a/src/cpdetect/compiler_detector/elf_compiler.cpp
+++ b/src/cpdetect/compiler_detector/elf_compiler.cpp
@@ -73,4 +73,3 @@ ElfCompiler::ElfCompiler(
 
 } // namespace cpdetect
 } // namespace retdec
-

--- a/src/cpdetect/compiler_detector/heuristics/pe_heuristics.cpp
+++ b/src/cpdetect/compiler_detector/heuristics/pe_heuristics.cpp
@@ -526,7 +526,7 @@ void PeHeuristics::getSecuROMHeuristics()
 	bool foundSecuROM = false;
 
 	// There must be at least 0x2000 extra bytes beyond the last section,
-	// last data directory, last debug directory and digital signature. 
+	// last data directory, last debug directory and digital signature.
 	if (peParser.getOverlaySize() >= 0x2000)
 	{
 		// The entire file must be loaded to memory
@@ -541,7 +541,7 @@ void PeHeuristics::getSecuROMHeuristics()
 				foundSecuROM = true;
 			if(checkSecuROMSignature(fileData, fileData + loadedLength, loadedLength - (SecuromOffs - 0x0C)))
 				foundSecuROM = true;
-			
+
 			if(foundSecuROM)
 			{
 				addPacker(DetectionMethod::STRING_SEARCH_H, DetectionStrength::HIGH, "SecuROM");

--- a/src/cpdetect/compiler_detector/heuristics/pe_heuristics.cpp
+++ b/src/cpdetect/compiler_detector/heuristics/pe_heuristics.cpp
@@ -404,7 +404,6 @@ void PeHeuristics::getMorphineHeuristics()
 void PeHeuristics::getStarForceHeuristics()
 {
 	const PeLib::MzHeader & mzHeader = peParser.getMzHeader();
-	const auto &content = search.getPlainString();
 	const auto epSection = toolInfo.epSection.getIndex();
 	uint32_t e_lfanew = mzHeader.getAddressOfPeHeader();
 	uint16_t e_cblp = mzHeader.getBytesOnLastPage();

--- a/src/cpdetect/compiler_detector/heuristics/pe_heuristics.cpp
+++ b/src/cpdetect/compiler_detector/heuristics/pe_heuristics.cpp
@@ -414,7 +414,7 @@ void PeHeuristics::getStarForceHeuristics()
 		if (search.exactComparison("68--------FF25", toolInfo.epOffset) || search.exactComparison("FF25", toolInfo.epOffset) || search.exactComparison("E8--------68ADDE0080FF15", toolInfo.epOffset))
 		{
 			// Version A
-			if (!strncmp(sections[0]->getName().c_str(), ".sforce", 7) && !strncmp(sections[epSection]->getName().c_str(), ".start", 6)  && (e_cblp == (uint16_t)e_lfanew) && (e_cp == 1))
+			if (!strncmp(sections[0]->getName().c_str(), ".sforce", 7) && !strncmp(sections[epSection]->getName().c_str(), ".start", 6) && (e_cblp == static_cast<uint16_t>(e_lfanew)) && (e_cp == 1))
 			{
 				addPacker(DetectionMethod::COMBINED, DetectionStrength::MEDIUM, "StarForce.A");
 				return;
@@ -496,7 +496,7 @@ bool PeHeuristics::checkSecuROMSignature(const char * fileData, const char * fil
 
 	if (fileData <= header && (header + 0x08) <= fileDataEnd)
 	{
-		uint32_t * secuRomHeader = (uint32_t *)header;
+		const uint32_t * secuRomHeader = reinterpret_cast<const uint32_t *>(header);
 
 		if (secuRomHeader[1] == SecuRomMagic)
 		{

--- a/src/cpdetect/compiler_detector/macho_compiler.cpp
+++ b/src/cpdetect/compiler_detector/macho_compiler.cpp
@@ -75,4 +75,3 @@ MachOCompiler::MachOCompiler(
 
 } // namespace cpdetect
 } // namespace retdec
-

--- a/src/cpdetect/compiler_detector/raw_data_compiler.cpp
+++ b/src/cpdetect/compiler_detector/raw_data_compiler.cpp
@@ -93,4 +93,3 @@ RawDataCompiler::RawDataCompiler(
 
 } // namespace cpdetect
 } // namespace retdec
-

--- a/src/ctypesparser/itanium_ast_ctypes_parser.cpp
+++ b/src/ctypesparser/itanium_ast_ctypes_parser.cpp
@@ -262,7 +262,7 @@ std::shared_ptr<ctypes::Type> ItaniumAstCtypesParser::parseNameTypeNode(
 
 	/*
 	 * if (name == "...") return type with name "..."; <-- is implicit
- 	 * is later used to check if function takes variable number of arguments
+	 * is later used to check if function takes variable number of arguments
 	 */
 	return ctypes::NamedType::create(context, name);
 }

--- a/src/demangler/borland_ast/rreference_type.cpp
+++ b/src/demangler/borland_ast/rreference_type.cpp
@@ -80,4 +80,3 @@ void RReferenceTypeNode::printRight(std::ostream &s) const
 }    // borland
 }    // demangler
 }    // retdec
-

--- a/src/demangler/borland_ast/type_node.cpp
+++ b/src/demangler/borland_ast/type_node.cpp
@@ -28,4 +28,3 @@ Qualifiers TypeNode::quals()
 }    // borland
 }    // demangler
 }    // retdec
-

--- a/src/demangler/context.cpp
+++ b/src/demangler/context.cpp
@@ -244,4 +244,3 @@ void Context::addArrayType(const std::shared_ptr<ArrayNode> &array) {
 }    // borland
 }    // demangler
 }    // retdec
-

--- a/src/fileformat/file_format/pe/pe_format.cpp
+++ b/src/fileformat/file_format/pe/pe_format.cpp
@@ -220,14 +220,14 @@ const std::map<std::size_t, std::string> resourceLanguageMap
 // http://www.hexacorn.com/blog/2016/12/15/pe-section-names-re-visited/
 const std::vector<std::string> usualSectionNames
 {
-	".00cfg", ".apiset", ".arch", ".autoload_text", ".bindat", ".bootdat", ".bss", 
+	".00cfg", ".apiset", ".arch", ".autoload_text", ".bindat", ".bootdat", ".bss",
 	".BSS", ".buildid", ".CLR_UEF", ".code", ".cormeta", ".complua", ".CRT",
-	".cygwin_dll_common", ".data", ".DATA", ".data1", ".data2", ".data3", ".debug", 
-	".debug  $F", ".debug  $P", ".debug  $S", ".debug  $T", ".drectve ", ".didat", 
-	".didata", ".edata", ".eh_fram", ".export", ".fasm", ".flat", ".gfids", ".giats", 
+	".cygwin_dll_common", ".data", ".DATA", ".data1", ".data2", ".data3", ".debug",
+	".debug  $F", ".debug  $P", ".debug  $S", ".debug  $T", ".drectve ", ".didat",
+	".didata", ".edata", ".eh_fram", ".export", ".fasm", ".flat", ".gfids", ".giats",
 	".gljmp", ".glue_7t", ".glue_7", ".idata", ".idlsym", ".impdata", ".import",
-	".itext", ".ndata", ".orpc", ".pdata", ".rdata", ".reloc", ".rodata", ".rsrc", 
-	".sbss", ".script", ".shared", ".sdata", ".srdata", ".stab", ".stabstr", ".sxdata", 
+	".itext", ".ndata", ".orpc", ".pdata", ".rdata", ".reloc", ".rodata", ".rsrc",
+	".sbss", ".script", ".shared", ".sdata", ".srdata", ".stab", ".stabstr", ".sxdata",
 	".text", ".text0", ".text1", ".text2", ".text3", ".textbss", ".tls", ".tls$",
 	".udata", ".vsdata", ".xdata", ".wixburn", ".wpp_sf", "BSS", "CODE", "DATA",
 	"DGROUP", "edata", "idata", "INIT", "minATL", "PAGE", "rdata", "sdata", "shared",

--- a/src/getsig/getsig.cpp
+++ b/src/getsig/getsig.cpp
@@ -533,4 +533,3 @@ int main(int argc, char** argv) {
 
 	return 0;
 }
-

--- a/src/stacofin/stacofin.cpp
+++ b/src/stacofin/stacofin.cpp
@@ -1082,7 +1082,6 @@ utils::Address Finder::getAddressFromRef_mips(utils::Address ref)
 }
 
 /**
-<<<<<<< variant A
  * On ARM, reference may be an instruction that needs to be disassembled and
  * inspected for reference target,
  * or
@@ -1387,12 +1386,10 @@ void Finder::checkRef_x86(Reference& ref)
  * Sometimes, we don't need references to solve detections.
  * e.g. on PIC32 detected function '_scanf_cdnopuxX' is in section
  * `.text._scanf_cdnopuxX`.
->>>>>>> variant B
  * Sort detected functions.
  *
  * Functions are sorted by their address, if detection address is same bigger
  * detection is first.
-======= end
  */
 void Finder::confirmWithoutRefs()
 {

--- a/tests/demangler/borland_tests.cpp
+++ b/tests/demangler/borland_tests.cpp
@@ -341,4 +341,3 @@ TEST_F(BorlandDemanglerTests, NonClassTemplates)
 } // namespace tests
 } // namespace demangler
 } // namespace retdec
-


### PR DESCRIPTION
Hi, a compilation of RetDec outputs warnings considering c-style casts and unused variables in the code. I tried to fix those errors in this PR.
Also, there were some whitespace errors I found in git output that I thought would be great if were fixed too.