### PR TITLE
Temporary fix to fix debug build of fileinfo in TeamCity with CMake 3.11.0

### DIFF
--- a/src/fileformat/CMakeLists.txt
+++ b/src/fileformat/CMakeLists.txt
@@ -75,6 +75,8 @@ set(FILEFORMAT_SOURCES
 	file_format/elf/elf_format.cpp
 )
 
+find_package(Threads REQUIRED)
+
 add_library(retdec-fileformat STATIC ${FILEFORMAT_SOURCES})
-target_link_libraries(retdec-fileformat retdec-crypto retdec-utils pelib elfio llvm)
+target_link_libraries(retdec-fileformat retdec-crypto retdec-utils pelib elfio llvm Threads::Threads)
 target_include_directories(retdec-fileformat PUBLIC ${PROJECT_SOURCE_DIR}/include/)


### PR DESCRIPTION
This should fix debug build of fileinfo in TeamCity with CMake 3.11.0 however this seems to be just a workaround for bug in CMake which is fixed since 3.13.0.