### PR TITLE
deps/yaracpp: update reference to yaracpp version that uses xcrun.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 * Fix: Fixed crashes of `retdec-unpacker` when trying to unpack corrupted ELF samples having incorrect size of additional data ([#582](https://github.com/avast/retdec/issues/582)).
 * Fix: Fixed several Mach-O parsing crashes ([#581](https://github.com/avast/retdec/issues/581), [#561](https://github.com/avast/retdec/issues/561), [#568](https://github.com/avast/retdec/issues/568)).
 * Fix: Fixed import table hashes computation - hashes are no longer produced from empty strings ([#460](https://github.com/avast/retdec/issues/460)).
+* Fix: Fixed build on macOS Mojave by updating OpenSSL and using `xcrun` ([#439](https://github.com/avast/retdec/issues/439)).
 
 # v3.3 (2019-03-18)
 

--- a/deps/yaracpp/CMakeLists.txt
+++ b/deps/yaracpp/CMakeLists.txt
@@ -31,8 +31,8 @@ else()
 	message(STATUS "YaraCpp: using remote YaraCpp revision.")
 
 	ExternalProject_Add(yaracpp-project
-		URL https://github.com/avast/yaracpp/archive/f5d97cd746398a49b23e62b62994722597407543.zip
-		URL_HASH SHA256=fece1814b0fac2888fc3356d414348f065c2d2eff86c27fee39e45b4a0b5e2c6
+		URL https://github.com/avast/yaracpp/archive/3417c9e855ebb06096571f54175e33c5efb0f774.zip
+		URL_HASH SHA256=5f37f7a3638351bd4ba24d1e7fcaa2aa74ad3c41151377ede99ccbd5fc5e079b
 		DOWNLOAD_NAME yaracpp.zip
 		CMAKE_ARGS
 			# This does not work on MSVC, but may be useful on Linux.


### PR DESCRIPTION
Fix #439.