### PR TITLE
Pass info of used calling conventions into config

### DIFF
--- a/include/retdec/bin2llvmir/optimizations/param_return/param_return.h
+++ b/include/retdec/bin2llvmir/optimizations/param_return/param_return.h
@@ -62,6 +62,7 @@ class ParamReturn : public llvm::ModulePass
 		void collectExtraData(CallEntry* ce) const;
 
 		void collectCallSpecificTypes(CallEntry* ce) const;
+		config::CallingConventionID toCallConv(const std::string &cc) const;
 
 	// Collection of functions usage data.
 	//

--- a/include/retdec/bin2llvmir/providers/abi/abi.h
+++ b/include/retdec/bin2llvmir/providers/abi/abi.h
@@ -104,9 +104,12 @@ class Abi
 	// Calling conventions.
 	//
 	public:
+		bool supportsCallingConvention(
+				const CallingConvention::ID& cc);
 		CallingConvention* getCallingConvention(
 				const CallingConvention::ID& cc);
 		CallingConvention* getDefaultCallingConvention();
+		CallingConvention::ID getDefaultCallingConventionID() const;
 
 	// Config.
 	//

--- a/include/retdec/config/calling_convention.h
+++ b/include/retdec/config/calling_convention.h
@@ -112,6 +112,7 @@ class CallingConvention
 		eCallingConvention getID() const;
 
 		friend std::ostream& operator<< (std::ostream &out, const eCallingConvention& cc);
+		CallingConvention& operator=(const eCallingConvention& cc);
 
 	private:
 		CallingConvention(eCallingConvention cc);

--- a/src/bin2llvmir/optimizations/param_return/param_return.cpp
+++ b/src/bin2llvmir/optimizations/param_return/param_return.cpp
@@ -961,6 +961,13 @@ void ParamReturn::applyToIr(DataFlowEntry& de)
 		}
 	}
 
+	// Set used calling convention to config
+	auto* cf = _config->getConfigFunction(fnc);
+	if (cf)
+	{
+		cf->callingConvention = de.getCallingConvention();
+	}
+
 	IrModifier irm(_module, _config);
 	auto* newFnc = irm.modifyFunction(
 			fnc,

--- a/src/bin2llvmir/optimizations/param_return/param_return.cpp
+++ b/src/bin2llvmir/optimizations/param_return/param_return.cpp
@@ -675,6 +675,14 @@ void ParamReturn::filterCalls()
 
 		filters[cc]->estimateRetValue(&de);
 
+		if (_abi->supportsCallingConvention(cc))
+		{
+			de.setCallingConvention(cc);
+		}
+		else
+		{
+			de.setCallingConvention(_abi->getDefaultCallingConventionID());
+		}
 		modifyType(de);
 
 		analyzeWithDemangler(de);

--- a/src/bin2llvmir/optimizations/param_return/param_return.cpp
+++ b/src/bin2llvmir/optimizations/param_return/param_return.cpp
@@ -36,24 +36,6 @@ namespace bin2llvmir {
 //=============================================================================
 //
 
-namespace {
-config::CallingConvention::eCallingConvention toCallConv(const std::string &callConv)
-{
-	using CallingConvention = config::CallingConvention::eCallingConvention;
-
-	std::map<std::string, CallingConvention> callConvMap {
-		{"cdecl", CallingConvention::CC_CDECL},
-		{"pascal", CallingConvention::CC_PASCAL},
-		{"thiscall", CallingConvention::CC_THISCALL},
-		{"stdcall", CallingConvention::CC_STDCALL},
-		{"fastcall", CallingConvention::CC_FASTCALL},
-		{"eabi", CallingConvention::CC_ARM}
-	};	// TODO add vectorcall and regcall
-
-	return utils::mapGetValueOrDefault(callConvMap, callConv, CallingConvention::CC_UNKNOWN);
-}
-}
-
 char ParamReturn::ID = 0;
 
 static RegisterPass<ParamReturn> X(
@@ -185,6 +167,20 @@ DataFlowEntry ParamReturn::createDataFlowEntry(Value* calledValue) const
 	collectExtraData(&dataflow);
 
 	return dataflow;
+}
+
+config::CallingConventionID ParamReturn::toCallConv(const std::string &cc) const
+{
+	std::map<std::string, config::CallingConventionID> ccMap {
+		{"cdecl", config::CallingConventionID::CC_CDECL},
+		{"pascal", config::CallingConventionID::CC_PASCAL},
+		{"thiscall", config::CallingConventionID::CC_THISCALL},
+		{"stdcall", config::CallingConventionID::CC_STDCALL},
+		{"fastcall", config::CallingConventionID::CC_FASTCALL},
+		{"eabi", config::CallingConventionID::CC_ARM}
+	};	// TODO add vectorcall and regcall
+
+	return utils::mapGetValueOrDefault(ccMap, cc, config::CallingConventionID::CC_UNKNOWN);
 }
 
 void ParamReturn::collectExtraData(DataFlowEntry* dataflow) const
@@ -681,8 +677,6 @@ void ParamReturn::filterCalls()
 
 		modifyType(de);
 
-//		dumpInfo(de);
-
 		analyzeWithDemangler(de);
 	}
 }
@@ -890,7 +884,6 @@ void ParamReturn::applyToIr()
 {
 	for (auto& p : _fnc2calls)
 	{
-//		dumpInfo(p.second);
 		applyToIr(p.second);
 	}
 

--- a/src/bin2llvmir/providers/abi/abi.cpp
+++ b/src/bin2llvmir/providers/abi/abi.cpp
@@ -264,6 +264,16 @@ bool Abi::isPic32() const
 	return _config->getConfig().architecture.isPic32();
 }
 
+bool Abi::supportsCallingConvention(const CallingConvention::ID& cc)
+{
+	return getCallingConvention(cc) != nullptr;
+}
+
+CallingConvention::ID Abi::getDefaultCallingConventionID() const
+{
+	return _defcc;
+}
+
 CallingConvention* Abi::getDefaultCallingConvention()
 {
 	return getCallingConvention(_defcc);

--- a/src/config/calling_convention.cpp
+++ b/src/config/calling_convention.cpp
@@ -24,7 +24,16 @@ const std::vector<std::string> ccStrings =
 	"spoiled",
 	"speciale",
 	"specialp",
-	"special"
+	"special",
+	"watcom",
+	"x64_os_default",
+	"arm_default",
+	"arm64_default",
+	"mips_default",
+	"mips64_default",
+	"powerpc_default",
+	"powerpc64_default",
+	"pic32_default"
 };
 
 } // anonymous namespace
@@ -154,6 +163,15 @@ std::ostream& operator<<(std::ostream &out, const CallingConventionID& cc)
 		case CallingConvention::eCallingConvention::CC_SPECIALE: out << "CC_SPECIALE"; break;
 		case CallingConvention::eCallingConvention::CC_SPECIALP: out << "CC_SPECIALP"; break;
 		case CallingConvention::eCallingConvention::CC_SPECIAL:  out << "CC_SPECIAL"; break;
+		case CallingConvention::eCallingConvention::CC_WATCOM:   out << "CC_WATCOM"; break;
+		case CallingConvention::eCallingConvention::CC_X64:      out << "CC_X64_OS_DEFAULT"; break;
+		case CallingConvention::eCallingConvention::CC_ARM:      out << "CC_ARM_DEFAULT"; break;
+		case CallingConvention::eCallingConvention::CC_ARM64:    out << "CC_ARM64_DEFAULT"; break;
+		case CallingConvention::eCallingConvention::CC_MIPS:     out << "CC_MIPS_DEFAULT"; break;
+		case CallingConvention::eCallingConvention::CC_MIPS64:   out << "CC_MIPS64_DEFAULT"; break;
+		case CallingConvention::eCallingConvention::CC_POWERPC:  out << "CC_POWERPC_DEFAULT"; break;
+		case CallingConvention::eCallingConvention::CC_POWERPC64:out << "CC_POWERPC64_DEFAULT"; break;
+		case CallingConvention::eCallingConvention::CC_PIC32:    out << "CC_PIC32_DEFAULT"; break;
 		default: out << "UNHANDLED"; break;
 	}
 	return out;

--- a/src/config/calling_convention.cpp
+++ b/src/config/calling_convention.cpp
@@ -166,5 +166,12 @@ std::ostream& operator<<(std::ostream &out, const CallingConvention& cc)
 	return out;
 }
 
+CallingConvention& CallingConvention::operator=(const CallingConventionID& cc)
+{
+	_callingConvention = cc;
+
+	return *this;
+}
+
 } // namespace config
 } // namespace retdec


### PR DESCRIPTION
Hi, this PR brings minor modifications into parameter optimization. With these modifications is info about calling conventions (that were used during the parameter analysis) projected into a configuration JSON output file after the optimization.

All architectures with only one calling convention set name of the calling convention to the config as `"arch_default"` (eg. `arm_default`, `mips_default`, etc.).

When it comes to x64, this architecture has two calling conventions that are used on different operating systems. On Windows, calling convention that is used is Microsoft x64. On UNIX like systems, it is System V convention.
For simplicity is therefor name of the convention saved into the config file as `"x64_os_default"`.

Example of `config.json` on x86:
```
{  
   "callingConvention":"cdecl",
   "name":"main",
   "parameters": [  
...
},
```

and before changes:
```
{  
   "callingConvention":"unknown",
   "name":"main",
   "parameters": [  
...
},
```
