### PR TITLE
Add a missing OpenSSL dependency on Unix: dl

### DIFF
--- a/deps/openssl/CMakeLists.txt
+++ b/deps/openssl/CMakeLists.txt
@@ -177,5 +177,7 @@ target_link_libraries(openssl-crypto INTERFACE "${OPENSSL_INSTALL_DIR}/lib/libcr
 target_link_libraries(openssl-crypto INTERFACE Threads::Threads)
 if(MSVC)
 	target_link_libraries(openssl-crypto INTERFACE ws2_32 gdi32 advapi32 crypt32 user32)
+elseif(UNIX)
+	target_link_libraries(openssl-crypto INTERFACE ${CMAKE_DL_LIBS})
 endif()
 add_dependencies(openssl-crypto openssl)


### PR DESCRIPTION
Without it, RetDec fails to build on some systems, e.g. via our `Dockerfile` that is based on Ubuntu Bionic and does not (at the time of writing) use a pre-built version of OpenSSL:

    ../../deps/openssl/openssl/src/openssl-install/lib/libcrypto.a(dso_dlfcn.o): In function `dlfcn_globallookup':
    dso_dlfcn.c:(.text+0x11): undefined reference to `dlopen'
    dso_dlfcn.c:(.text+0x24): undefined reference to `dlsym'
    dso_dlfcn.c:(.text+0x2f): undefined reference to `dlclose'

Reported in #623.