### PR TITLE
Improve the return value of utils::timestampToDate()

### DIFF
--- a/src/utils/time.cpp
+++ b/src/utils/time.cpp
@@ -87,7 +87,7 @@ std::string getCurrentYear() {
 */
 std::string timestampToDate(std::tm *tm) {
 	if (tm == nullptr) {
-		return "";
+		return {};
 	}
 
 	std::stringstream ss;


### PR DESCRIPTION
When constructing the empty string, it is better to use `std::string()` (or just `{}` when returning a value) instead of `""` as the latter calls a construct that needs to traverse the empty string literal, which is needless pessimization.