### PR TITLE
Try to fix issue #633

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 * Fix: Export ordinals are now correctly calculated as relative to the base ([#612](https://github.com/avast/retdec/issues/612), [avast/pelib#10](https://github.com/avast/pelib/pull/10)).
 * Fix: Fixed crash in the decoding phase ([#637](https://github.com/avast/retdec/issues/637), [#641](https://github.com/avast/retdec/pull/641)).
 * Fix: Fixed global variable naming issue ([#636](https://github.com/avast/retdec/issues/636), [#645](https://github.com/avast/retdec/pull/645)).
+* Fix: Fixed binary to LLVM IR translation of some MIPS instructions ([#633](https://github.com/avast/retdec/issues/633)), and made the translation process less error prone altogether ([#672](https://github.com/avast/retdec/pull/672)).
 
 # v3.3 (2019-03-18)
 

--- a/src/capstone2llvmir/arm/arm.cpp
+++ b/src/capstone2llvmir/arm/arm.cpp
@@ -865,7 +865,7 @@ void Capstone2LlvmIrTranslatorArm_impl::translateB(cs_insn* i, cs_arm* ai, llvm:
 {
 	EXPECT_IS_UNARY(i, ai, irb);
 
-	op0 = loadOpUnary(ai, irb);
+	op0 = loadOpsUnary(ai, irb);
 	bool isReturn = ai->operands[0].type == ARM_OP_REG
 			&& ai->operands[0].reg == ARM_REG_LR;
 
@@ -892,7 +892,7 @@ void Capstone2LlvmIrTranslatorArm_impl::translateBl(cs_insn* i, cs_arm* ai, llvm
 	EXPECT_IS_UNARY(i, ai, irb);
 
 	storeRegister(ARM_REG_LR, getNextInsnAddress(i), irb);
-	op0 = loadOpUnary(ai, irb);
+	op0 = loadOpsUnary(ai, irb);
 	if (ai->cc == ARM_CC_AL || ai->cc == ARM_CC_INVALID)
 	{
 		generateCallFunctionCall(irb, op0);
@@ -1115,14 +1115,14 @@ void Capstone2LlvmIrTranslatorArm_impl::translateMovt(cs_insn* i, cs_arm* ai, ll
 	// Add/Fix THUMB unit tests.
 	if (_basicMode == CS_MODE_THUMB)
 	{
-		std::tie(op0, op1) = loadOpBinary(ai, irb, eOpConv::ZEXT_TRUNC);
+		std::tie(op0, op1) = loadOpBinary(ai, irb, eOpConv::ZEXT_TRUNC_OR_BITCAST);
 		op1 = irb.CreateShl(op1, 16);
 		op0 = irb.CreateOr(op0, op1);
 		storeOp(ai->operands[0], op0, irb);
 	}
 	else
 	{
-		std::tie(op0, op1) = loadOpBinary(ai, irb, eOpConv::ZEXT_TRUNC);
+		std::tie(op0, op1) = loadOpBinary(ai, irb, eOpConv::ZEXT_TRUNC_OR_BITCAST);
 		op0 = irb.CreateAnd(op0, 0xffff);
 		op1 = irb.CreateShl(op1, 16);
 		op0 = irb.CreateOr(op0, op1);
@@ -1147,7 +1147,7 @@ void Capstone2LlvmIrTranslatorArm_impl::translateMovw(cs_insn* i, cs_arm* ai, ll
 	}
 	else
 	{
-		std::tie(op0, op1) = loadOpBinary(ai, irb, eOpConv::ZEXT_TRUNC);
+		std::tie(op0, op1) = loadOpBinary(ai, irb, eOpConv::ZEXT_TRUNC_OR_BITCAST);
 		op0 = irb.CreateAnd(op0, 0xffff0000);
 		op0 = irb.CreateOr(op0, op1);
 		storeOp(ai->operands[0], op0, irb);

--- a/src/capstone2llvmir/arm/arm.cpp
+++ b/src/capstone2llvmir/arm/arm.cpp
@@ -888,7 +888,7 @@ void Capstone2LlvmIrTranslatorArm_impl::translateB(cs_insn* i, cs_arm* ai, llvm:
 {
 	EXPECT_IS_UNARY(i, ai, irb);
 
-	op0 = loadOpsUnary(ai, irb);
+	op0 = loadOpUnary(ai, irb);
 	bool isReturn = ai->operands[0].type == ARM_OP_REG
 			&& ai->operands[0].reg == ARM_REG_LR;
 
@@ -915,7 +915,7 @@ void Capstone2LlvmIrTranslatorArm_impl::translateBl(cs_insn* i, cs_arm* ai, llvm
 	EXPECT_IS_UNARY(i, ai, irb);
 
 	storeRegister(ARM_REG_LR, getNextInsnAddress(i), irb);
-	op0 = loadOpsUnary(ai, irb);
+	op0 = loadOpUnary(ai, irb);
 	if (ai->cc == ARM_CC_AL || ai->cc == ARM_CC_INVALID)
 	{
 		generateCallFunctionCall(irb, op0);

--- a/src/capstone2llvmir/arm/arm.cpp
+++ b/src/capstone2llvmir/arm/arm.cpp
@@ -521,7 +521,30 @@ llvm::Instruction* Capstone2LlvmIrTranslatorArm_impl::storeRegister(
 	{
 		throw GenericError("storeRegister() unhandled reg.");
 	}
-	val = generateTypeConversion(irb, val, llvmReg->getValueType(), ct);
+	if (llvmReg->getValueType()->isFloatingPointTy())
+	{
+		switch (ct)
+		{
+			case eOpConv::SITOFP_OR_FPCAST:
+			case eOpConv::UITOFP_OR_FPCAST:
+				val = generateTypeConversion(irb, val, llvmReg->getValueType(), ct);
+				break;
+			default:
+				val = generateTypeConversion(irb, val, llvmReg->getValueType(), eOpConv::FPCAST_OR_BITCAST);
+		}
+	}
+	else
+	{
+		switch (ct)
+		{
+			case eOpConv::SEXT_TRUNC_OR_BITCAST:
+			case eOpConv::ZEXT_TRUNC_OR_BITCAST:
+				val = generateTypeConversion(irb, val, llvmReg->getValueType(), ct);
+				break;
+			default:
+				val = generateTypeConversion(irb, val, llvmReg->getValueType(), eOpConv::SEXT_TRUNC_OR_BITCAST);
+		}
+	}
 
 	return irb.CreateStore(val, llvmReg);
 }

--- a/src/capstone2llvmir/arm/arm_impl.h
+++ b/src/capstone2llvmir/arm/arm_impl.h
@@ -73,12 +73,12 @@ class Capstone2LlvmIrTranslatorArm_impl :
 				uint32_t r,
 				llvm::Value* val,
 				llvm::IRBuilder<>& irb,
-				eOpConv ct = eOpConv::SEXT_TRUNC) override;
+				eOpConv ct = eOpConv::SEXT_TRUNC_OR_BITCAST) override;
 		virtual llvm::Instruction* storeOp(
 				cs_arm_op& op,
 				llvm::Value* val,
 				llvm::IRBuilder<>& irb,
-				eOpConv ct = eOpConv::SEXT_TRUNC) override;
+				eOpConv ct = eOpConv::SEXT_TRUNC_OR_BITCAST) override;
 
 		llvm::Value* generateInsnConditionCode(
 				llvm::IRBuilder<>& irb,

--- a/src/capstone2llvmir/arm64/arm64.cpp
+++ b/src/capstone2llvmir/arm64/arm64.cpp
@@ -827,7 +827,30 @@ llvm::Instruction* Capstone2LlvmIrTranslatorArm64_impl::storeRegister(
 		return nullptr;
 	}
 
-	val = generateTypeConversion(irb, val, llvmReg->getValueType(), ct);
+	if (llvmReg->getValueType()->isFloatingPointTy())
+	{
+		switch (ct)
+		{
+			case eOpConv::SITOFP_OR_FPCAST:
+			case eOpConv::UITOFP_OR_FPCAST:
+				val = generateTypeConversion(irb, val, llvmReg->getValueType(), ct);
+				break;
+			default:
+				val = generateTypeConversion(irb, val, llvmReg->getValueType(), eOpConv::FPCAST_OR_BITCAST);
+		}
+	}
+	else
+	{
+		switch (ct)
+		{
+			case eOpConv::SEXT_TRUNC_OR_BITCAST:
+			case eOpConv::ZEXT_TRUNC_OR_BITCAST:
+				val = generateTypeConversion(irb, val, llvmReg->getValueType(), ct);
+				break;
+			default:
+				val = generateTypeConversion(irb, val, llvmReg->getValueType(), eOpConv::SEXT_TRUNC_OR_BITCAST);
+		}
+	}
 
 	return irb.CreateStore(val, llvmReg);
 }

--- a/src/capstone2llvmir/arm64/arm64.cpp
+++ b/src/capstone2llvmir/arm64/arm64.cpp
@@ -1855,7 +1855,7 @@ void Capstone2LlvmIrTranslatorArm64_impl::translateBr(cs_insn* i, cs_arm64* ai, 
 		storeRegister(ARM64_REG_LR, getNextInsnAddress(i), irb);
 	}
 
-	op0 = loadOpsUnary(ai, irb);
+	op0 = loadOpUnary(ai, irb);
 	generateBranchFunctionCall(irb, op0);
 }
 
@@ -1866,7 +1866,7 @@ void Capstone2LlvmIrTranslatorArm64_impl::translateB(cs_insn* i, cs_arm64* ai, l
 {
 	EXPECT_IS_UNARY(i, ai, irb);
 
-	op0 = loadOpsUnary(ai, irb);
+	op0 = loadOpUnary(ai, irb);
 
 	if (isCondIns(ai)) {
 		auto* cond = generateInsnConditionCode(irb, ai);
@@ -1886,7 +1886,7 @@ void Capstone2LlvmIrTranslatorArm64_impl::translateBl(cs_insn* i, cs_arm64* ai, 
 	EXPECT_IS_UNARY(i, ai, irb);
 
 	storeRegister(ARM64_REG_LR, getNextInsnAddress(i), irb);
-	op0 = loadOpsUnary(ai, irb);
+	op0 = loadOpUnary(ai, irb);
 	generateCallFunctionCall(irb, op0);
 }
 

--- a/src/capstone2llvmir/arm64/arm64.cpp
+++ b/src/capstone2llvmir/arm64/arm64.cpp
@@ -1138,8 +1138,7 @@ void Capstone2LlvmIrTranslatorArm64_impl::translateAdc(cs_insn* i, cs_arm64* ai,
 {
 	EXPECT_IS_TERNARY(i, ai, irb);
 
-	std::tie(op1, op2) = loadOpBinaryOrTernaryOp1Op2(ai, irb);
-	op2 = irb.CreateZExtOrTrunc(op2, op1->getType());
+	std::tie(op1, op2) = loadOpBinaryOrTernaryOp1Op2(ai, irb, eOpConv::ZEXT_TRUNC_OR_BITCAST);
 	auto* carry = loadRegister(ARM64_REG_CPSR_C, irb);
 
 	auto* val = irb.CreateAdd(op1, op2);
@@ -1165,7 +1164,7 @@ void Capstone2LlvmIrTranslatorArm64_impl::translateAdd(cs_insn* i, cs_arm64* ai,
 	EXPECT_IS_BINARY_OR_TERNARY(i, ai, irb);
 
 	std::tie(op1, op2) = loadOpBinaryOrTernaryOp1Op2(ai, irb);
-	op2 = generateTypeConversion(irb, op2, op1->getType(), eOpConv::ZEXT_TRUNC);
+	op2 = generateTypeConversion(irb, op2, op1->getType(), eOpConv::ZEXT_TRUNC_OR_BITCAST);
 
 	// For some reason it is possible to add two FP registers with integer add?
 	// This looks to be also true for sub
@@ -1199,7 +1198,7 @@ void Capstone2LlvmIrTranslatorArm64_impl::translateSub(cs_insn* i, cs_arm64* ai,
 	EXPECT_IS_BINARY_OR_TERNARY(i, ai, irb);
 
 	std::tie(op1, op2) = loadOpBinaryOrTernaryOp1Op2(ai, irb);
-	op2 = generateTypeConversion(irb, op2, op1->getType(), eOpConv::ZEXT_TRUNC);
+	op2 = generateTypeConversion(irb, op2, op1->getType(), eOpConv::ZEXT_TRUNC_OR_BITCAST);
 
 	// For some reason it is possible to sub two FP registers with integer sub?
 	// This looks to be also true for add
@@ -1664,12 +1663,12 @@ void Capstone2LlvmIrTranslatorArm64_impl::translateLdp(cs_insn* i, cs_arm64* ai,
 	case ARM64_INS_LDAXP:
 		data_size = llvm::ConstantInt::get(getDefaultType(), getRegisterByteSize(ai->operands[0].reg));
 		ty = getRegisterType(ai->operands[0].reg);
-		ct = eOpConv::ZEXT_TRUNC;
+		ct = eOpConv::ZEXT_TRUNC_OR_BITCAST;
 		break;
 	case ARM64_INS_LDPSW:
 		data_size = llvm::ConstantInt::get(getDefaultType(), 4);
 		ty = irb.getInt32Ty();
-		ct = eOpConv::SEXT_TRUNC;
+		ct = eOpConv::SEXT_TRUNC_OR_BITCAST;
 		break;
 	default:
 		throw GenericError("Arm64 Ldp: Instruction id error");
@@ -1833,7 +1832,7 @@ void Capstone2LlvmIrTranslatorArm64_impl::translateBr(cs_insn* i, cs_arm64* ai, 
 		storeRegister(ARM64_REG_LR, getNextInsnAddress(i), irb);
 	}
 
-	op0 = loadOpUnary(ai, irb);
+	op0 = loadOpsUnary(ai, irb);
 	generateBranchFunctionCall(irb, op0);
 }
 
@@ -1844,7 +1843,7 @@ void Capstone2LlvmIrTranslatorArm64_impl::translateB(cs_insn* i, cs_arm64* ai, l
 {
 	EXPECT_IS_UNARY(i, ai, irb);
 
-	op0 = loadOpUnary(ai, irb);
+	op0 = loadOpsUnary(ai, irb);
 
 	if (isCondIns(ai)) {
 		auto* cond = generateInsnConditionCode(irb, ai);
@@ -1864,7 +1863,7 @@ void Capstone2LlvmIrTranslatorArm64_impl::translateBl(cs_insn* i, cs_arm64* ai, 
 	EXPECT_IS_UNARY(i, ai, irb);
 
 	storeRegister(ARM64_REG_LR, getNextInsnAddress(i), irb);
-	op0 = loadOpUnary(ai, irb);
+	op0 = loadOpsUnary(ai, irb);
 	generateCallFunctionCall(irb, op0);
 }
 
@@ -2092,8 +2091,7 @@ void Capstone2LlvmIrTranslatorArm64_impl::translateEor(cs_insn* i, cs_arm64* ai,
 {
 	EXPECT_IS_BINARY_OR_TERNARY(i, ai, irb);
 
-	std::tie(op1, op2) = loadOpBinaryOrTernaryOp1Op2(ai, irb);
-	op2 = irb.CreateZExtOrTrunc(op2, op1->getType());
+	std::tie(op1, op2) = loadOpBinaryOrTernaryOp1Op2(ai, irb, eOpConv::ZEXT_TRUNC_OR_BITCAST);
 
 	if (i->id == ARM64_INS_EON)
 	{
@@ -2198,8 +2196,7 @@ void Capstone2LlvmIrTranslatorArm64_impl::translateOrr(cs_insn* i, cs_arm64* ai,
 {
 	EXPECT_IS_BINARY_OR_TERNARY(i, ai, irb);
 
-	std::tie(op1, op2) = loadOpBinaryOrTernaryOp1Op2(ai, irb);
-	op2 = irb.CreateZExtOrTrunc(op2, op1->getType());
+	std::tie(op1, op2) = loadOpBinaryOrTernaryOp1Op2(ai, irb, eOpConv::ZEXT_TRUNC_OR_BITCAST);
 
 	if (i->id == ARM64_INS_ORN)
 	{
@@ -2218,7 +2215,7 @@ void Capstone2LlvmIrTranslatorArm64_impl::translateDiv(cs_insn* i, cs_arm64* ai,
 {
 	EXPECT_IS_TERNARY(i, ai, irb);
 
-	std::tie(op1, op2) = loadOpBinaryOrTernaryOp1Op2(ai, irb);
+	std::tie(op1, op2) = loadOpBinaryOrTernaryOp1Op2(ai, irb, eOpConv::SEXT_TRUNC_OR_BITCAST);
 	llvm::Value *val = nullptr;
 	if (i->id == ARM64_INS_UDIV)
 	{
@@ -2640,7 +2637,7 @@ void Capstone2LlvmIrTranslatorArm64_impl::translateFCmp(cs_insn* i, cs_arm64* ai
 	op0 = loadOp(ai->operands[0], irb);
 	op1 = loadOp(ai->operands[1], irb);
 
-	op1 = generateTypeConversion(irb, op1, op0->getType(), eOpConv::FP_CAST);
+	op1 = generateTypeConversion(irb, op1, op0->getType(), eOpConv::FPCAST_OR_BITCAST);
 
 	// IF op1 == op2
 	auto* fcmpOeq = irb.CreateFCmpOEQ(op0, op1);
@@ -2703,7 +2700,7 @@ void Capstone2LlvmIrTranslatorArm64_impl::translateFCvt(cs_insn* i, cs_arm64* ai
 	EXPECT_IS_BINARY(i, ai, irb);
 
 	op1 = loadOp(ai->operands[1], irb);
-	storeOp(ai->operands[0], op1, irb);
+	storeOp(ai->operands[0], op1, irb, eOpConv::FPCAST_OR_BITCAST);
 }
 
 /**
@@ -2713,15 +2710,15 @@ void Capstone2LlvmIrTranslatorArm64_impl::translateFCvtf(cs_insn* i, cs_arm64* a
 {
 	EXPECT_IS_BINARY(i, ai, irb);
 
-	op1 = loadOp(ai->operands[1], irb);
+	op1 = loadOpBinaryOp1(ai, irb);
 
 	switch(i->id)
 	{
 	case ARM64_INS_UCVTF:
-		storeOp(ai->operands[0], op1, irb, eOpConv::UITOFP);
+		storeOp(ai->operands[0], op1, irb, eOpConv::UITOFP_OR_FPCAST);
 		break;
 	case ARM64_INS_SCVTF:
-		storeOp(ai->operands[0], op1, irb, eOpConv::SITOFP);
+		storeOp(ai->operands[0], op1, irb, eOpConv::SITOFP_OR_FPCAST);
 		break;
 	default:
 		throw GenericError("Arm64: translateFCvtf(): Unsupported instruction id");
@@ -2872,7 +2869,7 @@ void Capstone2LlvmIrTranslatorArm64_impl::translateFMov(cs_insn* i, cs_arm64* ai
 	op1 = loadOp(ai->operands[1], irb);
 	if (ai->operands[1].type == ARM64_OP_FP)
 	{
-		op1 = generateTypeConversion(irb, op1, getRegisterType(ai->operands[0].reg), eOpConv::FP_CAST);
+		op1 = generateTypeConversion(irb, op1, getRegisterType(ai->operands[0].reg), eOpConv::FPCAST_OR_BITCAST);
 	}
 	else
 	{
@@ -2902,7 +2899,7 @@ void Capstone2LlvmIrTranslatorArm64_impl::translateMovi(cs_insn* i, cs_arm64* ai
 	}
 
 	op1 = loadOp(ai->operands[1], irb);
-	storeOp(ai->operands[0], op1, irb);
+	storeOp(ai->operands[0], op1, irb, eOpConv::FPCAST_OR_BITCAST);
 }
 
 /**

--- a/src/capstone2llvmir/arm64/arm64_impl.h
+++ b/src/capstone2llvmir/arm64/arm64_impl.h
@@ -138,12 +138,12 @@ class Capstone2LlvmIrTranslatorArm64_impl :
 				uint32_t r,
 				llvm::Value* val,
 				llvm::IRBuilder<>& irb,
-				eOpConv ct = eOpConv::ZEXT_TRUNC) override;
+				eOpConv ct = eOpConv::ZEXT_TRUNC_OR_BITCAST) override;
 		virtual llvm::Instruction* storeOp(
 				cs_arm64_op& op,
 				llvm::Value* val,
 				llvm::IRBuilder<>& irb,
-				eOpConv ct = eOpConv::ZEXT_TRUNC) override;
+				eOpConv ct = eOpConv::ZEXT_TRUNC_OR_BITCAST) override;
 
 		/**
 		* @brief This functions will generate psuedo asm translation.

--- a/src/capstone2llvmir/capstone2llvmir_impl.cpp
+++ b/src/capstone2llvmir/capstone2llvmir_impl.cpp
@@ -1102,7 +1102,7 @@ Capstone2LlvmIrTranslator_impl<CInsn, CInsnOp>::_loadOpsUniversal(
  * Throws if op_count != 1.
  */
 template <typename CInsn, typename CInsnOp>
-llvm::Value* Capstone2LlvmIrTranslator_impl<CInsn, CInsnOp>::loadOpsUnary(
+llvm::Value* Capstone2LlvmIrTranslator_impl<CInsn, CInsnOp>::loadOpUnary(
 		CInsn* ci,
 		llvm::IRBuilder<>& irb,
 		llvm::Type* loadType,

--- a/src/capstone2llvmir/capstone2llvmir_impl.cpp
+++ b/src/capstone2llvmir/capstone2llvmir_impl.cpp
@@ -1042,14 +1042,14 @@ std::vector<llvm::Value*> Capstone2LlvmIrTranslator_impl<CInsn, CInsnOp>::_loadO
 	{
 		auto* op0 = loadOp(ci, irb, startOp, loadType, dstType, ct);
 		dstType = op0->getType();
-		dstType = checkTypeConversion(irb, dstType, ct);
+		dstType = _checkTypeConversion(irb, dstType, ct);
 		op0 = generateTypeConversion(irb, op0, dstType, ct);
 		startOp++;
 		operands.push_back(op0);
 	}
 	else
 	{
-		auto* type = checkTypeConversion(irb, dstType, ct);
+		auto* type = _checkTypeConversion(irb, dstType, ct);
 		if (type != dstType)
 		{
 			throw GenericError(
@@ -1747,7 +1747,7 @@ llvm::Value* Capstone2LlvmIrTranslator_impl<CInsn, CInsnOp>::generateTypeConvers
 }
 
 template <typename CInsn, typename CInsnOp>
-llvm::Type* Capstone2LlvmIrTranslator_impl<CInsn, CInsnOp>::checkTypeConversion(
+llvm::Type* Capstone2LlvmIrTranslator_impl<CInsn, CInsnOp>::_checkTypeConversion(
 		llvm::IRBuilder<>& irb,
 		llvm::Type* to,
 		eOpConv ct)

--- a/src/capstone2llvmir/capstone2llvmir_impl.cpp
+++ b/src/capstone2llvmir/capstone2llvmir_impl.cpp
@@ -982,30 +982,134 @@ llvm::GlobalVariable* Capstone2LlvmIrTranslator_impl<CInsn, CInsnOp>::createRegi
 //==============================================================================
 //
 
+
+template <typename CInsn, typename CInsnOp>
+llvm::Value* Capstone2LlvmIrTranslator_impl<CInsn, CInsnOp>::loadOp(
+		CInsn* ci,
+		llvm::IRBuilder<>& irb,
+		std::size_t idx,
+		llvm::Type* loadType,
+		llvm::Type* dstType,
+		eOpConv ct)
+{
+	if (ci->op_count <= idx)
+	{
+		throw GenericError(
+				"Idx out of bounds: "+std::to_string(idx)
+				+"/"+std::to_string(ci->op_count));
+	}
+
+	auto* op = loadOp(ci->operands[idx], irb, loadType);
+	if (op == nullptr)
+	{
+		throw GenericError("Operand loading failed.");
+	}
+
+	if (dstType == nullptr)
+	{
+		return op;
+	}
+
+	return generateTypeConversion(irb, op, dstType, ct);
+}
+
+template <typename CInsn, typename CInsnOp>
+std::vector<llvm::Value*> Capstone2LlvmIrTranslator_impl<CInsn, CInsnOp>::_loadOps(
+		CInsn* ci,
+		llvm::IRBuilder<>& irb,
+		std::size_t opCnt,
+		bool strict,
+		llvm::Type* loadType,
+		llvm::Type* dstType,
+		eOpConv ct)
+{
+	if ((strict && (ci->op_count != opCnt)) || (ci->op_count < opCnt))
+	{
+		throw GenericError(
+				"Trying to load "
+				+std::to_string(opCnt)
+				+" operands from instruction with"
+				+std::to_string(ci->op_count)
+				+" opernads.");
+	}
+
+	std::size_t startOp = ci->op_count - opCnt;
+
+	std::vector<llvm::Value*> operands;
+
+	// If no destination type specified, use type of first operand.
+	if (dstType == nullptr)
+	{
+		auto* op0 = loadOp(ci, irb, startOp, loadType, dstType, ct);
+		dstType = op0->getType();
+		dstType = checkTypeConversion(irb, dstType, ct);
+		op0 = generateTypeConversion(irb, op0, dstType, ct);
+		startOp++;
+		operands.push_back(op0);
+	}
+	else
+	{
+		auto* type = checkTypeConversion(irb, dstType, ct);
+		if (type != dstType)
+		{
+			throw GenericError(
+				"Invalid combination of destination type and conversion type.");
+		}
+	}
+
+	for (; startOp < ci->op_count; startOp++) {
+		auto* op = loadOp(ci, irb, startOp, loadType, dstType, ct);
+		operands.push_back(op);
+	}
+
+	return operands;
+}
+
+template <typename CInsn, typename CInsnOp>
+std::vector<llvm::Value*>
+Capstone2LlvmIrTranslator_impl<CInsn, CInsnOp>::_loadOpsUniversal(
+		CInsn* ci,
+		llvm::IRBuilder<>& irb,
+		std::size_t opCnt,
+		bool strict,
+		eOpConv ict,
+		eOpConv fct)
+{
+	if ((strict && (ci->op_count != opCnt)) || (ci->op_count < opCnt))
+	{
+		throw GenericError(
+				"Trying to load "
+				+std::to_string(opCnt)
+				+" operands from instruction with"
+				+std::to_string(ci->op_count)
+				+" opernads.");
+	}
+
+	auto op0 = loadOp(ci, irb, ci->op_count - opCnt);
+	if (op0->getType()->isIntegerTy())
+	{
+		auto operands = _loadOps(ci, irb, opCnt-1, false, nullptr, op0->getType(), ict);
+		operands.insert(operands.begin(), op0);
+		return operands;
+	}
+
+	auto operands = _loadOps(ci, irb, opCnt-1, false, nullptr, op0->getType(), fct);
+	operands.insert(operands.begin(), op0);
+	return operands;
+}
+
 /**
  * Throws if op_count != 1.
  */
 template <typename CInsn, typename CInsnOp>
-llvm::Value* Capstone2LlvmIrTranslator_impl<CInsn, CInsnOp>::loadOpUnary(
+llvm::Value* Capstone2LlvmIrTranslator_impl<CInsn, CInsnOp>::loadOpsUnary(
 		CInsn* ci,
 		llvm::IRBuilder<>& irb,
+		llvm::Type* loadType,
 		llvm::Type* dstType,
-		eOpConv ct,
-		llvm::Type* loadType)
+		eOpConv ct)
 {
-	if (ci->op_count != 1)
-	{
-		throw GenericError("This is not an unary instruction.");
-	}
-
-	auto* op0 = loadOp(ci->operands[0], irb, loadType);
-	if (op0 == nullptr)
-	{
-		throw GenericError("Operand loading failed.");
-	}
-	op0 = generateTypeConversion(irb, op0, dstType, ct);
-
-	return op0;
+	return _loadOps(ci, irb, 1, true, loadType, dstType, ct)[0];
 }
 
 /**
@@ -1018,20 +1122,36 @@ Capstone2LlvmIrTranslator_impl<CInsn, CInsnOp>::loadOpBinary(
 		llvm::IRBuilder<>& irb,
 		eOpConv ct)
 {
-	if (ci->op_count != 2)
-	{
-		throw GenericError("This is not a binary instruction.");
-	}
+	auto operands = _loadOps(ci, irb, 2, true, nullptr, nullptr, ct);
+	return std::make_pair(operands[0], operands[1]);
+}
 
-	auto* op0 = loadOp(ci->operands[0], irb);
-	auto* op1 = loadOp(ci->operands[1], irb);
-	if (op0 == nullptr || op1 == nullptr)
-	{
-		throw GenericError("Operands loading failed.");
-	}
-	op1 = generateTypeConversion(irb, op1, op0->getType(), ct);
+/**
+ * Throws if op_count != 2.
+ */
+template <typename CInsn, typename CInsnOp>
+std::pair<llvm::Value*, llvm::Value*>
+Capstone2LlvmIrTranslator_impl<CInsn, CInsnOp>::loadOpBinary(
+		CInsn* ci,
+		llvm::IRBuilder<>& irb,
+		eOpConv ict,
+		eOpConv fct)
+{
+	auto operands = _loadOpsUniversal(ci, irb, 2, true, ict, fct);
+	return std::make_pair(operands[0], operands[1]);
+}
 
-	return std::make_pair(op0, op1);
+template <typename CInsn, typename CInsnOp>
+std::pair<llvm::Value*, llvm::Value*>
+Capstone2LlvmIrTranslator_impl<CInsn, CInsnOp>::loadOpBinary(
+		CInsn* ci,
+		llvm::IRBuilder<>& irb,
+		llvm::Type* loadType,
+		llvm::Type* dstType,
+		eOpConv ct)
+{
+	auto operands = _loadOps(ci, irb, 2, true, loadType, dstType, ct);
+	return std::make_pair(operands[0], operands[1]);
 }
 
 /**
@@ -1043,12 +1163,8 @@ llvm::Value* Capstone2LlvmIrTranslator_impl<CInsn, CInsnOp>::loadOpBinaryOp0(
 		llvm::IRBuilder<>& irb,
 		llvm::Type* ty)
 {
-	if (ci->op_count != 2)
-	{
-		throw GenericError("This is not a binary instruction.");
-	}
-
-	return loadOp(ci->operands[0], irb, ty);
+	auto operand = loadOp(ci, irb, 0, ty);
+	return operand;
 }
 
 /**
@@ -1060,12 +1176,8 @@ llvm::Value* Capstone2LlvmIrTranslator_impl<CInsn, CInsnOp>::loadOpBinaryOp1(
 		llvm::IRBuilder<>& irb,
 		llvm::Type* ty)
 {
-	if (ci->op_count != 2)
-	{
-		throw GenericError("This is not a binary instruction.");
-	}
-
-	return loadOp(ci->operands[1], irb, ty);
+	auto operand = loadOp(ci, irb, 1, ty);
+	return operand;
 }
 
 /**
@@ -1075,23 +1187,45 @@ template <typename CInsn, typename CInsnOp>
 std::tuple<llvm::Value*, llvm::Value*, llvm::Value*>
 Capstone2LlvmIrTranslator_impl<CInsn, CInsnOp>::loadOpTernary(
 		CInsn* ci,
-		llvm::IRBuilder<>& irb)
+		llvm::IRBuilder<>& irb,
+		eOpConv ct)
 {
-	if (ci->op_count != 3)
-	{
-		throw GenericError("This is not a ternary instruction.");
-	}
-
-	auto* op0 = loadOp(ci->operands[0], irb);
-	auto* op1 = loadOp(ci->operands[1], irb);
-	auto* op2 = loadOp(ci->operands[2], irb);
-	if (op0 == nullptr || op1 == nullptr || op2 == nullptr)
-	{
-		throw GenericError("Operands loading failed.");
-	}
-
-	return std::make_tuple(op0, op1, op2);
+	auto operands = _loadOps(ci, irb, 3, true, nullptr, nullptr, ct);
+	return std::make_tuple(operands[0], operands[1], operands[2]);
 }
+
+/**
+ * Throws if op_count != 3.
+ */
+template <typename CInsn, typename CInsnOp>
+std::tuple<llvm::Value*, llvm::Value*, llvm::Value*>
+Capstone2LlvmIrTranslator_impl<CInsn, CInsnOp>::loadOpTernary(
+		CInsn* ci,
+		llvm::IRBuilder<>& irb,
+		eOpConv ict,
+		eOpConv fct)
+{
+	auto operands = _loadOpsUniversal(ci, irb, 3, true, ict, fct);
+	return std::make_tuple(operands[0], operands[1], operands[2]);
+}
+
+
+/**
+ * Throws if op_count != 3.
+ */
+template <typename CInsn, typename CInsnOp>
+std::tuple<llvm::Value*, llvm::Value*, llvm::Value*>
+Capstone2LlvmIrTranslator_impl<CInsn, CInsnOp>::loadOpTernary(
+		CInsn* ci,
+		llvm::IRBuilder<>& irb,
+		llvm::Type* loadType,
+		llvm::Type* dstType,
+		eOpConv ct)
+{
+	auto operands = _loadOps(ci, irb, 3, true, loadType, dstType, ct);
+	return std::make_tuple(operands[0], operands[1], operands[2]);
+}
+
 
 /**
  * Throws if op_count not in {2, 3}.
@@ -1103,31 +1237,23 @@ Capstone2LlvmIrTranslator_impl<CInsn, CInsnOp>::loadOpBinaryOrTernaryOp1Op2(
 		llvm::IRBuilder<>& irb,
 		eOpConv ct)
 {
-	llvm::Value* op1 = nullptr;
-	llvm::Value* op2 = nullptr;
+	auto operands = _loadOps(ci, irb, 2, false, nullptr, nullptr, ct);
+	return std::make_pair(operands[0], operands[1]);
+}
 
-	// TODO: Is this desirable here? Maybe special function with this behaviour?
-	if (ci->op_count == 2)
-	{
-		op1 = loadOp(ci->operands[0], irb);
-		op2 = loadOp(ci->operands[1], irb);
-	}
-	else if (ci->op_count == 3)
-	{
-		op1 = loadOp(ci->operands[1], irb);
-		op2 = loadOp(ci->operands[2], irb);
-	}
-	else
-	{
-		throw GenericError("This is not a ternary instruction.");
-	}
-	if (op1 == nullptr || op2 == nullptr)
-	{
-		throw GenericError("Operands loading failed.");
-	}
-	op2 = generateTypeConversion(irb, op2, op1->getType(), ct);
-
-	return std::make_pair(op1, op2);
+/**
+ * Throws if op_count not in {2, 3}.
+ */
+template <typename CInsn, typename CInsnOp>
+std::pair<llvm::Value*, llvm::Value*>
+Capstone2LlvmIrTranslator_impl<CInsn, CInsnOp>::loadOpBinaryOrTernaryOp1Op2(
+		CInsn* ci,
+		llvm::IRBuilder<>& irb,
+		eOpConv ict,
+		eOpConv fct)
+{
+	auto operands = _loadOpsUniversal(ci, irb, 2, false, ict, fct);
+	return std::make_pair(operands[0], operands[1]);
 }
 
 /**
@@ -1139,20 +1265,8 @@ Capstone2LlvmIrTranslator_impl<CInsn, CInsnOp>::loadOpQuaternaryOp1Op2Op3(
 		CInsn* ci,
 		llvm::IRBuilder<>& irb)
 {
-	if (ci->op_count != 4)
-	{
-		throw GenericError("This is not a ternary instruction.");
-	}
-
-	auto* op1 = loadOp(ci->operands[1], irb);
-	auto* op2 = loadOp(ci->operands[2], irb);
-	auto* op3 = loadOp(ci->operands[3], irb);
-	if (op1 == nullptr || op2 == nullptr || op3 == nullptr)
-	{
-		throw GenericError("Operands loading failed.");
-	}
-
-	return std::make_tuple(op1, op2, op3);
+	auto operands = _loadOps(ci, irb, 3, false);
+	return std::make_tuple(operands[0], operands[1], operands[2]);
 }
 
 //
@@ -1238,7 +1352,7 @@ llvm::Value* Capstone2LlvmIrTranslator_impl<CInsn, CInsnOp>::generateCarryAddCIn
 				getCarryRegister(),
 				irb,
 				a->getType(),
-				eOpConv::ZEXT_TRUNC);
+				eOpConv::ZEXT_TRUNC_OR_BITCAST);
 	}
 	auto* cfc = irb.CreateZExtOrTrunc(cf, a->getType());
 	auto* add = irb.CreateAdd(a, cfc);
@@ -1506,69 +1620,115 @@ llvm::Value* Capstone2LlvmIrTranslator_impl<CInsn, CInsnOp>::generateTypeConvers
 
 	switch (ct)
 	{
-		case eOpConv::SEXT_TRUNC:
+		case eOpConv::SEXT_TRUNC_OR_BITCAST:
 		{
-			if (from->getType()->isIntegerTy() && to->isIntegerTy())
+			if (!to->isIntegerTy())
+			{
+				throw GenericError("Invalid combination of conversion method and destination type");
+			}
+
+			if (from->getType()->isIntegerTy())
 			{
 				ret = irb.CreateSExtOrTrunc(from, to);
 			}
-			else if (from->getType()->isFloatingPointTy()
-					&& to->isFloatingPointTy())
-			{
-				ret = irb.CreateFPCast(from, to);
-			}
-			else if (from->getType()->isIntegerTy() && to->isFloatingPointTy())
-			{
-				ret = irb.CreateSIToFP(from, to);
-			}
-			else if (from->getType()->isFloatingPointTy() && to->isIntegerTy())
-			{
-				ret = irb.CreateFPToSI(from, to);
-			}
 			else
 			{
-				throw GenericError("Unhandled eOpConv::SEXT_TRUNC conversion.");
+				auto size = _module->getDataLayout().getTypeStoreSizeInBits(from->getType());
+				auto intTy = irb.getIntNTy(size);
+				ret = irb.CreateBitCast(from, intTy);
+				ret = irb.CreateZExtOrTrunc(ret, to);
 			}
 			break;
 		}
-		case eOpConv::ZEXT_TRUNC:
+		case eOpConv::ZEXT_TRUNC_OR_BITCAST:
 		{
-			if (from->getType()->isIntegerTy() && to->isIntegerTy())
+			if (!to->isIntegerTy())
+			{
+				throw GenericError("Invalid combination of conversion method and destination type");
+			}
+
+			if (from->getType()->isIntegerTy())
 			{
 				ret = irb.CreateZExtOrTrunc(from, to);
 			}
-			else if (from->getType()->isFloatingPointTy()
-					&& to->isFloatingPointTy())
+			else
+			{
+				auto size = _module->getDataLayout().getTypeStoreSizeInBits(from->getType());
+				auto intTy = irb.getIntNTy(size);
+				ret = irb.CreateBitCast(from, intTy);
+				ret = irb.CreateZExtOrTrunc(ret, to);
+			}
+			break;
+		}
+		case eOpConv::FPCAST_OR_BITCAST:
+		{
+			if (!to->isFloatingPointTy())
+			{
+				throw GenericError("Invalid combination of conversion method and destination type");
+			}
+
+			if (from->getType()->isFloatingPointTy())
 			{
 				ret = irb.CreateFPCast(from, to);
 			}
-			else if (from->getType()->isIntegerTy() && to->isFloatingPointTy())
+			else
 			{
-				ret = irb.CreateUIToFP(from, to);
+				auto isize = _module->getDataLayout().getTypeStoreSizeInBits(from->getType());
+				auto dsize = _module->getDataLayout().getTypeStoreSizeInBits(irb.getDoubleTy());
+				auto fsize = _module->getDataLayout().getTypeStoreSizeInBits(irb.getFloatTy());
+				auto lsize = _module->getDataLayout().getTypeStoreSizeInBits(llvm::Type::getFP128Ty(_module->getContext()));
+
+				if (isize == fsize)
+				{
+					from = irb.CreateBitCast(from, irb.getFloatTy());
+				}
+				else if (isize == dsize)
+				{
+					from = irb.CreateBitCast(from, irb.getDoubleTy());
+				}
+				else if (isize == lsize)
+				{
+					from = irb.CreateBitCast(from, llvm::Type::getFP128Ty(_module->getContext()));
+				}
+				else
+				{
+					throw GenericError("Unable to create bitcast to floating point type.");
+				}
+
+				ret = irb.CreateFPCast(from, to);
 			}
-			else if (from->getType()->isFloatingPointTy() && to->isIntegerTy())
+			break;
+		}
+		case eOpConv::SITOFP_OR_FPCAST:
+		{
+			if (!to->isFloatingPointTy())
 			{
-				ret = irb.CreateFPToUI(from, to);
+				throw GenericError("Invalid combination of conversion method and destination type");
+			}
+			if (from->getType()->isFloatingPointTy())
+			{
+				ret = irb.CreateFPCast(from, to);
 			}
 			else
 			{
-				throw GenericError("Unhandled eOpConv::ZEXT_TRUNC conversion.");
+				ret = irb.CreateSIToFP(from, to);
 			}
 			break;
 		}
-		case eOpConv::FP_CAST:
+		case eOpConv::UITOFP_OR_FPCAST:
 		{
-			ret = irb.CreateFPCast(from, to);
-			break;
-		}
-		case eOpConv::SITOFP:
-		{
-			ret = irb.CreateSIToFP(from, to);
-			break;
-		}
-		case eOpConv::UITOFP:
-		{
-			ret = irb.CreateUIToFP(from, to);
+			if (!to->isFloatingPointTy())
+			{
+				throw GenericError("Invalid combination of conversion method and destination type");
+			}
+			if (from->getType()->isFloatingPointTy())
+			{
+				ret = irb.CreateFPCast(from, to);
+			}
+			else
+			{
+				ret = irb.CreateUIToFP(from, to);
+			}
 			break;
 		}
 		case eOpConv::NOTHING:
@@ -1584,6 +1744,51 @@ llvm::Value* Capstone2LlvmIrTranslator_impl<CInsn, CInsnOp>::generateTypeConvers
 	}
 
 	return ret;
+}
+
+template <typename CInsn, typename CInsnOp>
+llvm::Type* Capstone2LlvmIrTranslator_impl<CInsn, CInsnOp>::checkTypeConversion(
+		llvm::IRBuilder<>& irb,
+		llvm::Type* to,
+		eOpConv ct)
+{
+	switch (ct)
+	{
+		case eOpConv::ZEXT_TRUNC_OR_BITCAST:
+		case eOpConv::SEXT_TRUNC_OR_BITCAST:
+		{
+			if (!to->isIntegerTy())
+			{
+				auto size = _module->getDataLayout().getTypeStoreSizeInBits(to);
+				return irb.getIntNTy(size);
+			}
+			break;
+		}
+		case eOpConv::FPCAST_OR_BITCAST:
+		case eOpConv::SITOFP_OR_FPCAST:
+		case eOpConv::UITOFP_OR_FPCAST:
+		{
+			if (!to->isFloatingPointTy())
+			{
+				auto flSize = _module->getDataLayout().getTypeStoreSizeInBits(
+							irb.getFloatTy());
+				auto size = _module->getDataLayout().getTypeStoreSizeInBits(to);
+				if (size <= flSize)
+				{
+					return irb.getFloatTy();
+				}
+
+				return irb.getDoubleTy();
+			}
+			break;
+		}
+		default:
+		{
+			return to;
+		}
+	}
+
+	return to;
 }
 
 /**

--- a/src/capstone2llvmir/capstone2llvmir_impl.h
+++ b/src/capstone2llvmir/capstone2llvmir_impl.h
@@ -185,7 +185,18 @@ class Capstone2LlvmIrTranslator_impl : virtual public Capstone2LlvmIrTranslator
 				llvm::Type* to,
 				eOpConv ct);
 
-		llvm::Type* checkTypeConversion(
+		/**
+		 * Internal method used to correct type used for operands
+		 * convertion based on specified "convertion type method" - ct.
+		 *
+		 * @param irb   LLVM IR Builder required for IR modifications.
+		 * @param to    result type that will be used to convert operands.
+		 * @param ct    convertion method by which will be opeands converted to the resut type.
+		 * @return      If result type for convertion can be used with specified conversion method
+		 *              returns param to. Otherwise will this method try to create suitable type
+		 *              for convertion method ct with size of llvm type of param to.
+		 */
+		llvm::Type* _checkTypeConversion(
 				llvm::IRBuilder<>& irb,
 				llvm::Type* to,
 				eOpConv ct);

--- a/src/capstone2llvmir/capstone2llvmir_impl.h
+++ b/src/capstone2llvmir/capstone2llvmir_impl.h
@@ -161,27 +161,32 @@ class Capstone2LlvmIrTranslator_impl : virtual public Capstone2LlvmIrTranslator
 			THROW,
 			/// Operand types does not have to be equal.
 			NOTHING,
-			/// Convert to destination type using ZEXT or TRUNC.
-			/// Types must be integer, or LLVM asserts.
-			ZEXT_TRUNC,
-			/// Convert to destination type using SEXT or TRUNC.
-			/// Types must be integer, or LLVM asserts.
-			SEXT_TRUNC,
-			/// Convert to destination type using FPCast (FPExt, BitCast,
+			/// Convert to destination integer type using ZEXT or TRUNC.
+			/// If source is FP type converts it using bitcast.
+			ZEXT_TRUNC_OR_BITCAST,
+			/// Convert to destination integer type using SEXT or TRUNC.
+			/// If source is FP type converts it using bitcast.
+			SEXT_TRUNC_OR_BITCAST,
+			/// Convert to destination FP type using FPCast (FPExt, BitCast,
 			/// or FPTrunc).
-			/// Types must be floating point, or LLVM asserts.
-			FP_CAST,
-			/// Convert to destination type using SIToFP.
+			/// If source is integer type converts it using bitcast.
+			FPCAST_OR_BITCAST,
+			/// Convert to destination FP type using SIToFP.
 			/// Source must be integer, destination fp, or LLVM asserts.
-			SITOFP,
-			/// Convert to destination type using UIToFP.
+			SITOFP_OR_FPCAST,
+			/// Convert to destination FP type using UIToFP.
 			/// Source must be integer, destination fp, or LLVM asserts.
-			UITOFP
+			UITOFP_OR_FPCAST
 		};
 
 		llvm::Value* generateTypeConversion(
 				llvm::IRBuilder<>& irb,
 				llvm::Value* from,
+				llvm::Type* to,
+				eOpConv ct);
+
+		llvm::Type* checkTypeConversion(
+				llvm::IRBuilder<>& irb,
 				llvm::Type* to,
 				eOpConv ct);
 //
@@ -325,24 +330,95 @@ class Capstone2LlvmIrTranslator_impl : virtual public Capstone2LlvmIrTranslator
 				uint32_t r,
 				llvm::Value* val,
 				llvm::IRBuilder<>& irb,
-				eOpConv ct = eOpConv::SEXT_TRUNC) = 0;
+				eOpConv ct = eOpConv::SEXT_TRUNC_OR_BITCAST) = 0;
 		virtual llvm::Instruction* storeOp(
 				CInsnOp& op,
 				llvm::Value* val,
 				llvm::IRBuilder<>& irb,
-				eOpConv ct = eOpConv::SEXT_TRUNC) = 0;
+				eOpConv ct = eOpConv::SEXT_TRUNC_OR_BITCAST) = 0;
 
-		llvm::Value* loadOpUnary(
+		/**
+		 * Creates LLVM load from LLVM value representing
+		 * openrand of instruction ci on index idx. User
+		 * of this method may specify type to which will be
+		 * loaded value converted and method of the conversion.
+		 *
+		 * @param ci	Instruction of which operand will be loaded.
+		 * @param irb	LLVM IR Builder required for IR modifications.
+		 * @param loadType	Type of loaded value. (not relevant if nullptr)
+		 * @param dstType	Desired type of loaded value (not changed if nullptr).
+		 * @param ct		Used conversion. Defaultly NOTHING as "do not convert".
+		 */
+		llvm::Value* loadOp(
+				CInsn* ci,
+				llvm::IRBuilder<>& irb,
+				std::size_t idx,
+				llvm::Type* loadType = nullptr,
+				llvm::Type* dstType = nullptr,
+				eOpConv ct = eOpConv::NOTHING);
+
+		/**
+		 * Create LLVM loads for LLVM values representing last N operands
+		 * (opCnt) of specified instruction. If strict check is set, this
+		 * method will check wheater number of operands of the instructions
+		 * is equal to the "opCnt". If conversion type is set to NOTHING
+		 * no conversion will happen and each operand may have different
+		 * size and type.
+		 *
+		 * This method was created to be used in internal load
+		 * methods. Usage of adequate loadOp(Binary|Ternary|...)
+		 * is preffered.
+		 *
+		 * @param ci	Instruction of which operands will be loaded.
+		 * @param irb	LLVM IR Builder required for IR modifications.
+		 * @param opCnt	Number of operands that will be loaded.
+		 * @param strictCheck	If set to true opCnt will be equal as number of operands. Otherwise will load N last operands.
+		 * @param loadType	Type of loaded value. (not relevant if nullptr)
+		 * @param dstType	Desired type of loaded value (not changed if nullptr).
+		 * @param ct		Used conversion. Defaultly NOTHING as "do not convert".
+		 */
+		std::vector<llvm::Value*> _loadOps(
+				CInsn* ci,
+				llvm::IRBuilder<>& irb,
+				std::size_t opCnt,
+				bool strictCheck = true,
+				llvm::Type* loadType = nullptr,
+				llvm::Type* dstType = nullptr,
+				eOpConv ct = eOpConv::NOTHING);
+
+		std::vector<llvm::Value*> _loadOpsUniversal(
+				CInsn* ci,
+				llvm::IRBuilder<>& irb,
+				std::size_t opCnt,
+				bool strictCheck = true,
+				eOpConv ict = eOpConv::SEXT_TRUNC_OR_BITCAST,
+				eOpConv fct = eOpConv::FPCAST_OR_BITCAST);
+
+		llvm::Value* loadOpsUnary(
 				CInsn* ci,
 				llvm::IRBuilder<>& irb,
 				llvm::Type* dstType = nullptr,
-				eOpConv ct = eOpConv::THROW,
-				llvm::Type* loadType = nullptr);
+				llvm::Type* loadType = nullptr,
+				eOpConv ct = eOpConv::THROW);
 
 		std::pair<llvm::Value*, llvm::Value*> loadOpBinary(
 				CInsn* ci,
 				llvm::IRBuilder<>& irb,
 				eOpConv ct = eOpConv::NOTHING);
+
+		std::pair<llvm::Value*, llvm::Value*> loadOpBinary(
+				CInsn* ci,
+				llvm::IRBuilder<>& irb,
+				eOpConv ict,
+				eOpConv fct);
+
+		std::pair<llvm::Value*, llvm::Value*> loadOpBinary(
+				CInsn* ci,
+				llvm::IRBuilder<>& irb,
+				llvm::Type* loadType,
+				llvm::Type* dstType = nullptr,
+				eOpConv ct = eOpConv::NOTHING);
+
 		llvm::Value* loadOpBinaryOp0(
 				CInsn* ci,
 				llvm::IRBuilder<>& irb,
@@ -354,11 +430,30 @@ class Capstone2LlvmIrTranslator_impl : virtual public Capstone2LlvmIrTranslator
 
 		std::tuple<llvm::Value*, llvm::Value*, llvm::Value*> loadOpTernary(
 				CInsn* ci,
-				llvm::IRBuilder<>& irb);
+				llvm::IRBuilder<>& irb,
+				eOpConv ct = eOpConv::NOTHING);
+		std::tuple<llvm::Value*, llvm::Value*, llvm::Value*> loadOpTernary(
+				CInsn* ci,
+				llvm::IRBuilder<>& irb,
+				eOpConv ict,
+				eOpConv fct);
+		std::tuple<llvm::Value*, llvm::Value*, llvm::Value*> loadOpTernary(
+				CInsn* ci,
+				llvm::IRBuilder<>& irb,
+				llvm::Type* loadType,
+				llvm::Type* dstType = nullptr,
+				eOpConv ct = eOpConv::NOTHING);
+
 		std::pair<llvm::Value*, llvm::Value*> loadOpBinaryOrTernaryOp1Op2(
 				CInsn* ai,
 				llvm::IRBuilder<>& irb,
 				eOpConv ct = eOpConv::NOTHING);
+
+		std::pair<llvm::Value*, llvm::Value*> loadOpBinaryOrTernaryOp1Op2(
+				CInsn* ai,
+				llvm::IRBuilder<>& irb,
+				eOpConv ict,
+				eOpConv fct);
 
 		std::tuple<llvm::Value*, llvm::Value*, llvm::Value*> loadOpQuaternaryOp1Op2Op3(
 				CInsn* ai,

--- a/src/capstone2llvmir/capstone2llvmir_impl.h
+++ b/src/capstone2llvmir/capstone2llvmir_impl.h
@@ -408,7 +408,7 @@ class Capstone2LlvmIrTranslator_impl : virtual public Capstone2LlvmIrTranslator
 				eOpConv ict = eOpConv::SEXT_TRUNC_OR_BITCAST,
 				eOpConv fct = eOpConv::FPCAST_OR_BITCAST);
 
-		llvm::Value* loadOpsUnary(
+		llvm::Value* loadOpUnary(
 				CInsn* ci,
 				llvm::IRBuilder<>& irb,
 				llvm::Type* dstType = nullptr,

--- a/src/capstone2llvmir/capstone2llvmir_impl.h
+++ b/src/capstone2llvmir/capstone2llvmir_impl.h
@@ -386,6 +386,15 @@ class Capstone2LlvmIrTranslator_impl : virtual public Capstone2LlvmIrTranslator
 				llvm::Type* dstType = nullptr,
 				eOpConv ct = eOpConv::NOTHING);
 
+		/**
+		 * Similiar functionality as `_loadOps` but used conversion is determined
+		 * by type of first loaded operand. This means that if first operand
+		 * is of integer type then `ict` convertion will be used on all other opernads.
+		 * If first perand is floting point type then used convertion will be `fct`.
+		 *
+		 * @param ict	Integer convertion type.
+		 * @param fct	Floting point convertion type.
+		 */
 		std::vector<llvm::Value*> _loadOpsUniversal(
 				CInsn* ci,
 				llvm::IRBuilder<>& irb,

--- a/src/capstone2llvmir/capstone2llvmir_impl.h
+++ b/src/capstone2llvmir/capstone2llvmir_impl.h
@@ -339,15 +339,16 @@ class Capstone2LlvmIrTranslator_impl : virtual public Capstone2LlvmIrTranslator
 
 		/**
 		 * Creates LLVM load from LLVM value representing
-		 * openrand of instruction ci on index idx. User
+		 * operand of instruction ci on index idx. User
 		 * of this method may specify type to which will be
 		 * loaded value converted and method of the conversion.
 		 *
-		 * @param ci	Instruction of which operand will be loaded.
-		 * @param irb	LLVM IR Builder required for IR modifications.
-		 * @param loadType	Type of loaded value. (not relevant if nullptr)
-		 * @param dstType	Desired type of loaded value (not changed if nullptr).
-		 * @param ct		Used conversion. Defaultly NOTHING as "do not convert".
+		 * @param ci       Instruction of which operand will be loaded.
+		 * @param irb      LLVM IR Builder required for IR modifications.
+		 * @param idx      Operand index.
+		 * @param loadType Type of loaded value. (not relevant if nullptr)
+		 * @param dstType  Desired type of loaded value (not changed if nullptr).
+		 * @param ct       Used conversion. Defaultly NOTHING as "do not convert".
 		 */
 		llvm::Value* loadOp(
 				CInsn* ci,
@@ -392,6 +393,10 @@ class Capstone2LlvmIrTranslator_impl : virtual public Capstone2LlvmIrTranslator
 		 * is of integer type then `ict` convertion will be used on all other opernads.
 		 * If first perand is floting point type then used convertion will be `fct`.
 		 *
+		 * @param ci
+		 * @param irb
+		 * @param opCnt
+		 * @param strictCheck
 		 * @param ict	Integer convertion type.
 		 * @param fct	Floting point convertion type.
 		 */

--- a/src/capstone2llvmir/mips/mips.cpp
+++ b/src/capstone2llvmir/mips/mips.cpp
@@ -402,7 +402,7 @@ llvm::StoreInst* Capstone2LlvmIrTranslatorMips_impl::storeRegister(
 	{
 		throw GenericError("storeRegister() unhandled reg.");
 	}
-	val = generateTypeConversion(irb, val, llvmReg->getValueType(), ct);
+	val = generateTypeConversion(irb, val, llvmReg->getValueType(),  llvmReg->getValueType()->isFloatingPointTy()? eOpConv::FPCAST_OR_BITCAST : ct);
 
 	return irb.CreateStore(val, llvmReg);
 }
@@ -506,7 +506,7 @@ void Capstone2LlvmIrTranslatorMips_impl::translateAdd(cs_insn* i, cs_mips* mi, l
 {
 	EXPECT_IS_BINARY_OR_TERNARY(i, mi, irb);
 
-	std::tie(op1, op2) = loadOpBinaryOrTernaryOp1Op2(mi, irb, eOpConv::SEXT_TRUNC);
+	std::tie(op1, op2) = loadOpBinaryOrTernaryOp1Op2(mi, irb, eOpConv::SEXT_TRUNC_OR_BITCAST, eOpConv::FPCAST_OR_BITCAST);
 	auto* add = op1->getType()->isFloatingPointTy()
 			? irb.CreateFAdd(op1, op2)
 			: irb.CreateAdd(op1, op2);
@@ -520,7 +520,7 @@ void Capstone2LlvmIrTranslatorMips_impl::translateAnd(cs_insn* i, cs_mips* mi, l
 {
 	EXPECT_IS_BINARY_OR_TERNARY(i, mi, irb);
 
-	std::tie(op1, op2) = loadOpBinaryOrTernaryOp1Op2(mi, irb, eOpConv::ZEXT_TRUNC);
+	std::tie(op1, op2) = loadOpBinaryOrTernaryOp1Op2(mi, irb, eOpConv::ZEXT_TRUNC_OR_BITCAST);
 	auto* a = irb.CreateAnd(op1, op2);
 	storeOp(mi->operands[0], a, irb);
 }
@@ -535,7 +535,7 @@ void Capstone2LlvmIrTranslatorMips_impl::translateBc1f(cs_insn* i, cs_mips* mi, 
 	if (mi->op_count == 1)
 	{
 		op0 = loadRegister(MIPS_REG_FCC0, irb); // implied operand
-		op1 = loadOpUnary(mi, irb);
+		op1 = loadOpsUnary(mi, irb);
 	}
 	else if (mi->op_count == 2)
 	{
@@ -556,7 +556,7 @@ void Capstone2LlvmIrTranslatorMips_impl::translateBc1t(cs_insn* i, cs_mips* mi, 
 	if (mi->op_count == 1)
 	{
 		op0 = loadRegister(MIPS_REG_FCC0, irb); // implied operand
-		op1 = loadOpUnary(mi, irb);
+		op1 = loadOpsUnary(mi, irb);
 	}
 	else if (mi->op_count == 2)
 	{
@@ -651,7 +651,7 @@ void Capstone2LlvmIrTranslatorMips_impl::translateCvt(cs_insn* i, cs_mips* mi, l
 	else if (mnem == "cvt.d.s")
 	{
 		op1 = irb.CreateLoad(getRegister(r1));
-		storeRegister(r0, op1, irb, eOpConv::FP_CAST);
+		storeRegister(r0, op1, irb, eOpConv::SITOFP_OR_FPCAST);
 	}
 	else if (mnem == "cvt.d.w" // should be only on MIPS32
 			|| mnem == "cvt.d.l") // should be only on MIPS64
@@ -662,7 +662,7 @@ void Capstone2LlvmIrTranslatorMips_impl::translateCvt(cs_insn* i, cs_mips* mi, l
 				: irb.getInt32Ty();
 		op1 = irb.CreateBitCast(op1, iTy);
 		op1 = irb.CreateSIToFP(op1, irb.getDoubleTy());
-		storeRegister(r0, op1, irb, eOpConv::FP_CAST);
+		storeRegister(r0, op1, irb, eOpConv::SITOFP_OR_FPCAST);
 	}
 	// CVT.W.fmt
 	//
@@ -788,7 +788,7 @@ void Capstone2LlvmIrTranslatorMips_impl::translateBreak(cs_insn* i, cs_mips* mi,
 	}
 	else if (mi->op_count == 1)
 	{
-		op0 = loadOpUnary(mi, irb);
+		op0 = loadOpsUnary(mi, irb);
 	}
 	else if (mi->op_count == 2)
 	{
@@ -898,7 +898,7 @@ void Capstone2LlvmIrTranslatorMips_impl::translateC(cs_insn* i, cs_mips* mi, llv
 		return;
 	}
 
-	storeRegister(MIPS_REG_FCC0, val, irb, eOpConv::ZEXT_TRUNC);
+	storeRegister(MIPS_REG_FCC0, val, irb, eOpConv::ZEXT_TRUNC_OR_BITCAST);
 }
 
 /**
@@ -943,7 +943,7 @@ void Capstone2LlvmIrTranslatorMips_impl::translateDiv(cs_insn* i, cs_mips* mi, l
 	{
 		EXPECT_IS_BINARY_OR_TERNARY(i, mi, irb);
 
-		std::tie(op1, op2) = loadOpBinaryOrTernaryOp1Op2(mi, irb, eOpConv::THROW);
+		std::tie(op1, op2) = loadOpBinaryOrTernaryOp1Op2(mi, irb, eOpConv::SITOFP_OR_FPCAST);
 		auto* div = irb.CreateFDiv(op1, op2);
 		storeOp(mi->operands[0], div, irb);
 	}
@@ -951,7 +951,8 @@ void Capstone2LlvmIrTranslatorMips_impl::translateDiv(cs_insn* i, cs_mips* mi, l
 	{
 		EXPECT_IS_BINARY(i, mi, irb);
 
-		std::tie(op0, op1) = loadOpBinary(mi, irb, eOpConv::THROW);
+		std::tie(op0, op1) = loadOpBinary(mi, irb, eOpConv::SEXT_TRUNC_OR_BITCAST);
+
 		auto* div = irb.CreateSDiv(op0, op1);
 		storeRegister(MIPS_REG_LO, div, irb);
 		auto* rem = irb.CreateSRem(op0, op1);
@@ -966,7 +967,7 @@ void Capstone2LlvmIrTranslatorMips_impl::translateDivu(cs_insn* i, cs_mips* mi, 
 {
 	EXPECT_IS_BINARY(i, mi, irb);
 
-	std::tie(op0, op1) = loadOpBinary(mi, irb, eOpConv::THROW);
+	std::tie(op0, op1) = loadOpBinary(mi, irb, eOpConv::SEXT_TRUNC_OR_BITCAST);
 	auto* div = irb.CreateUDiv(op0, op1);
 	storeRegister(MIPS_REG_LO, div, irb);
 	auto* rem = irb.CreateURem(op0, op1);
@@ -1032,7 +1033,7 @@ void Capstone2LlvmIrTranslatorMips_impl::translateJ(cs_insn* i, cs_mips* mi, llv
 {
 	EXPECT_IS_UNARY(i, mi, irb);
 
-	op0 = loadOpUnary(mi, irb);
+	op0 = loadOpsUnary(mi, irb);
 	generateBranchFunctionCall(irb, op0);
 }
 
@@ -1045,7 +1046,7 @@ void Capstone2LlvmIrTranslatorMips_impl::translateJal(cs_insn* i, cs_mips* mi, l
 	EXPECT_IS_UNARY(i, mi, irb);
 
 	storeRegister(MIPS_REG_RA, getNextNextInsnAddress(i), irb);
-	op0 = loadOpUnary(mi, irb);
+	op0 = loadOpsUnary(mi, irb);
 	generateCallFunctionCall(irb, op0);
 }
 
@@ -1065,21 +1066,21 @@ void Capstone2LlvmIrTranslatorMips_impl::translateLoadMemory(cs_insn* i, cs_mips
 
 	switch (i->id)
 	{
-		case MIPS_INS_LB: ty = irb.getInt8Ty(); ct = eOpConv::SEXT_TRUNC; break;
-		case MIPS_INS_LBU: ty = irb.getInt8Ty(); ct = eOpConv::ZEXT_TRUNC; break;
-		case MIPS_INS_LH: ty = irb.getInt16Ty(); ct = eOpConv::SEXT_TRUNC; break;
-		case MIPS_INS_LHU: ty = irb.getInt16Ty(); ct = eOpConv::ZEXT_TRUNC; break;
-		case MIPS_INS_LW: ty = irb.getInt32Ty(); ct = eOpConv::SEXT_TRUNC; break;
-		case MIPS_INS_LWU: ty = irb.getInt32Ty(); ct = eOpConv::ZEXT_TRUNC; break;
-		case MIPS_INS_LD: ty = irb.getInt64Ty(); ct = eOpConv::SEXT_TRUNC; break;
-		case MIPS_INS_LDC3: ty = irb.getInt64Ty(); ct = eOpConv::SEXT_TRUNC; break;
-		case MIPS_INS_LWC1: ty = irb.getFloatTy(); ct = eOpConv::FP_CAST; break;
-		case MIPS_INS_LDC1: ty = irb.getDoubleTy(); ct = eOpConv::FP_CAST; break;
+		case MIPS_INS_LB: ty = irb.getInt8Ty(); ct = eOpConv::SEXT_TRUNC_OR_BITCAST; break;
+		case MIPS_INS_LBU: ty = irb.getInt8Ty(); ct = eOpConv::ZEXT_TRUNC_OR_BITCAST; break;
+		case MIPS_INS_LH: ty = irb.getInt16Ty(); ct = eOpConv::SEXT_TRUNC_OR_BITCAST; break;
+		case MIPS_INS_LHU: ty = irb.getInt16Ty(); ct = eOpConv::ZEXT_TRUNC_OR_BITCAST; break;
+		case MIPS_INS_LW: ty = irb.getInt32Ty(); ct = eOpConv::SEXT_TRUNC_OR_BITCAST; break;
+		case MIPS_INS_LWU: ty = irb.getInt32Ty(); ct = eOpConv::ZEXT_TRUNC_OR_BITCAST; break;
+		case MIPS_INS_LD: ty = irb.getInt64Ty(); ct = eOpConv::SEXT_TRUNC_OR_BITCAST; break;
+		case MIPS_INS_LDC3: ty = irb.getInt64Ty(); ct = eOpConv::SEXT_TRUNC_OR_BITCAST; break;
+		case MIPS_INS_LWC1: ty = irb.getFloatTy(); ct = eOpConv::FPCAST_OR_BITCAST; break;
+		case MIPS_INS_LDC1: ty = irb.getDoubleTy(); ct = eOpConv::FPCAST_OR_BITCAST; break;
 		default:
 			throw GenericError("Unhandled insn ID in translateLoadMemory().");
 	}
 
-	op1 = loadOpBinaryOp1(mi, irb, ty);
+	op1 = loadOp(mi->operands[1], irb, ty);
 	storeOp(mi->operands[0], op1, irb, ct);
 }
 
@@ -1463,7 +1464,7 @@ void Capstone2LlvmIrTranslatorMips_impl::translateMthi(cs_insn* i, cs_mips* mi, 
 {
 	EXPECT_IS_UNARY(i, mi, irb);
 
-	op0 = loadOpUnary(mi, irb);
+	op0 = loadOpsUnary(mi, irb);
 	storeRegister(MIPS_REG_HI, op0, irb);
 }
 
@@ -1474,7 +1475,7 @@ void Capstone2LlvmIrTranslatorMips_impl::translateMtlo(cs_insn* i, cs_mips* mi, 
 {
 	EXPECT_IS_UNARY(i, mi, irb);
 
-	op0 = loadOpUnary(mi, irb);
+	op0 = loadOpsUnary(mi, irb);
 	storeRegister(MIPS_REG_LO, op0, irb);
 }
 
@@ -1598,7 +1599,7 @@ void Capstone2LlvmIrTranslatorMips_impl::translateNor(cs_insn* i, cs_mips* mi, l
 {
 	EXPECT_IS_BINARY_OR_TERNARY(i, mi, irb);
 
-	std::tie(op1, op2) = loadOpBinaryOrTernaryOp1Op2(mi, irb, eOpConv::ZEXT_TRUNC);
+	std::tie(op1, op2) = loadOpBinaryOrTernaryOp1Op2(mi, irb, eOpConv::ZEXT_TRUNC_OR_BITCAST);
 	auto* o = irb.CreateOr(op1, op2);
 	auto* x = irb.CreateXor(o, llvm::ConstantInt::getSigned(o->getType(), -1));
 	storeOp(mi->operands[0], x, irb);
@@ -1623,9 +1624,9 @@ void Capstone2LlvmIrTranslatorMips_impl::translateOr(cs_insn* i, cs_mips* mi, ll
 {
 	EXPECT_IS_BINARY_OR_TERNARY(i, mi, irb);
 
-	std::tie(op1, op2) = loadOpBinaryOrTernaryOp1Op2(mi, irb, eOpConv::ZEXT_TRUNC);
+	std::tie(op1, op2) = loadOpBinaryOrTernaryOp1Op2(mi, irb, eOpConv::ZEXT_TRUNC_OR_BITCAST);
 	auto* o = irb.CreateOr(op1, op2);
-	storeOp(mi->operands[0], o, irb);
+	storeOp(mi->operands[0], o, irb, eOpConv::ZEXT_TRUNC_OR_BITCAST);
 }
 
 /**
@@ -1635,7 +1636,7 @@ void Capstone2LlvmIrTranslatorMips_impl::translateRotr(cs_insn* i, cs_mips* mi, 
 {
 	EXPECT_IS_BINARY_OR_TERNARY(i, mi, irb);
 
-	std::tie(op1, op2) = loadOpBinaryOrTernaryOp1Op2(mi, irb, eOpConv::ZEXT_TRUNC);
+	std::tie(op1, op2) = loadOpBinaryOrTernaryOp1Op2(mi, irb, eOpConv::ZEXT_TRUNC_OR_BITCAST);
 	op2 = irb.CreateAnd(op2, llvm::ConstantInt::get(op2->getType(), 31)); // low 5 bits
 	auto* lshr = irb.CreateLShr(op1, op2);
 	auto* sub = irb.CreateSub(llvm::ConstantInt::get(op2->getType(), 32), op2);
@@ -1683,7 +1684,7 @@ void Capstone2LlvmIrTranslatorMips_impl::translateSll(cs_insn* i, cs_mips* mi, l
 {
 	EXPECT_IS_BINARY_OR_TERNARY(i, mi, irb);
 
-	std::tie(op1, op2) = loadOpBinaryOrTernaryOp1Op2(mi, irb, eOpConv::ZEXT_TRUNC);
+	std::tie(op1, op2) = loadOpBinaryOrTernaryOp1Op2(mi, irb, eOpConv::ZEXT_TRUNC_OR_BITCAST);
 	auto* shl = irb.CreateShl(op1, op2);
 	storeOp(mi->operands[0], shl, irb);
 }
@@ -1695,7 +1696,7 @@ void Capstone2LlvmIrTranslatorMips_impl::translateSlt(cs_insn* i, cs_mips* mi, l
 {
 	EXPECT_IS_BINARY_OR_TERNARY(i, mi, irb);
 
-	std::tie(op1, op2) = loadOpBinaryOrTernaryOp1Op2(mi, irb, eOpConv::SEXT_TRUNC);
+	std::tie(op1, op2) = loadOpBinaryOrTernaryOp1Op2(mi, irb, eOpConv::SEXT_TRUNC_OR_BITCAST);
 	auto* slt = irb.CreateICmpSLT(op1, op2);
 	slt = irb.CreateZExt(slt, getDefaultType());
 	storeOp(mi->operands[0], slt, irb);
@@ -1708,7 +1709,7 @@ void Capstone2LlvmIrTranslatorMips_impl::translateSltu(cs_insn* i, cs_mips* mi, 
 {
 	EXPECT_IS_BINARY_OR_TERNARY(i, mi, irb);
 
-	std::tie(op1, op2) = loadOpBinaryOrTernaryOp1Op2(mi, irb, eOpConv::SEXT_TRUNC);
+	std::tie(op1, op2) = loadOpBinaryOrTernaryOp1Op2(mi, irb, eOpConv::SEXT_TRUNC_OR_BITCAST);
 	auto* ult = irb.CreateICmpULT(op1, op2);
 	ult = irb.CreateZExt(ult, getDefaultType());
 	storeOp(mi->operands[0], ult, irb);
@@ -1721,7 +1722,7 @@ void Capstone2LlvmIrTranslatorMips_impl::translateSra(cs_insn* i, cs_mips* mi, l
 {
 	EXPECT_IS_BINARY_OR_TERNARY(i, mi, irb);
 
-	std::tie(op1, op2) = loadOpBinaryOrTernaryOp1Op2(mi, irb, eOpConv::ZEXT_TRUNC);
+	std::tie(op1, op2) = loadOpBinaryOrTernaryOp1Op2(mi, irb, eOpConv::ZEXT_TRUNC_OR_BITCAST);
 	auto* sra = irb.CreateAShr(op1, op2);
 	storeOp(mi->operands[0], sra, irb);
 }
@@ -1733,7 +1734,7 @@ void Capstone2LlvmIrTranslatorMips_impl::translateSrl(cs_insn* i, cs_mips* mi, l
 {
 	EXPECT_IS_BINARY_OR_TERNARY(i, mi, irb);
 
-	std::tie(op1, op2) = loadOpBinaryOrTernaryOp1Op2(mi, irb, eOpConv::ZEXT_TRUNC);
+	std::tie(op1, op2) = loadOpBinaryOrTernaryOp1Op2(mi, irb, eOpConv::ZEXT_TRUNC_OR_BITCAST);
 	auto* shr = irb.CreateLShr(op1, op2);
 	storeOp(mi->operands[0], shr, irb);
 }
@@ -1745,7 +1746,7 @@ void Capstone2LlvmIrTranslatorMips_impl::translateSub(cs_insn* i, cs_mips* mi, l
 {
 	EXPECT_IS_BINARY_OR_TERNARY(i, mi, irb);
 
-	std::tie(op1, op2) = loadOpBinaryOrTernaryOp1Op2(mi, irb, eOpConv::SEXT_TRUNC);
+	std::tie(op1, op2) = loadOpBinaryOrTernaryOp1Op2(mi, irb, eOpConv::SEXT_TRUNC_OR_BITCAST, eOpConv::FPCAST_OR_BITCAST);
 	auto* sub = op1->getType()->isFloatingPointTy()
 			? irb.CreateFSub(op1, op2)
 			: irb.CreateSub(op1, op2);
@@ -1765,7 +1766,7 @@ void Capstone2LlvmIrTranslatorMips_impl::translateSyscall(cs_insn* i, cs_mips* m
 	}
 	else if (mi->op_count == 1)
 	{
-		op0 = loadOpUnary(mi, irb);
+		op0 = loadOpsUnary(mi, irb);
 	}
 
 	op0 = irb.CreateZExtOrTrunc(op0, getDefaultType());
@@ -1785,7 +1786,7 @@ void Capstone2LlvmIrTranslatorMips_impl::translateXor(cs_insn* i, cs_mips* mi, l
 {
 	EXPECT_IS_BINARY_OR_TERNARY(i, mi, irb);
 
-	std::tie(op1, op2) = loadOpBinaryOrTernaryOp1Op2(mi, irb, eOpConv::ZEXT_TRUNC);
+	std::tie(op1, op2) = loadOpBinaryOrTernaryOp1Op2(mi, irb, eOpConv::ZEXT_TRUNC_OR_BITCAST);
 	auto* x = irb.CreateXor(op1, op2);
 	storeOp(mi->operands[0], x, irb);
 }
@@ -1798,9 +1799,9 @@ void Capstone2LlvmIrTranslatorMips_impl::translateSne(cs_insn* i, cs_mips* mi, l
 {
 	EXPECT_IS_BINARY_OR_TERNARY(i, mi, irb);
 
-	std::tie(op1, op2) = loadOpBinaryOrTernaryOp1Op2(mi, irb, eOpConv::SEXT_TRUNC);
+	std::tie(op1, op2) = loadOpBinaryOrTernaryOp1Op2(mi, irb, eOpConv::SEXT_TRUNC_OR_BITCAST);
 	auto* ne = irb.CreateICmpNE(op1, op2);
-	storeOp(mi->operands[0], ne, irb, eOpConv::ZEXT_TRUNC);
+	storeOp(mi->operands[0], ne, irb, eOpConv::ZEXT_TRUNC_OR_BITCAST);
 }
 
 /**
@@ -1811,9 +1812,9 @@ void Capstone2LlvmIrTranslatorMips_impl::translateSeq(cs_insn* i, cs_mips* mi, l
 {
 	EXPECT_IS_BINARY_OR_TERNARY(i, mi, irb);
 
-	std::tie(op1, op2) = loadOpBinaryOrTernaryOp1Op2(mi, irb, eOpConv::SEXT_TRUNC);
+	std::tie(op1, op2) = loadOpBinaryOrTernaryOp1Op2(mi, irb, eOpConv::SEXT_TRUNC_OR_BITCAST);
 	auto* ne = irb.CreateICmpEQ(op1, op2);
-	storeOp(mi->operands[0], ne, irb, eOpConv::ZEXT_TRUNC);
+	storeOp(mi->operands[0], ne, irb, eOpConv::ZEXT_TRUNC_OR_BITCAST);
 }
 
 } // namespace capstone2llvmir

--- a/src/capstone2llvmir/mips/mips.cpp
+++ b/src/capstone2llvmir/mips/mips.cpp
@@ -535,7 +535,7 @@ void Capstone2LlvmIrTranslatorMips_impl::translateBc1f(cs_insn* i, cs_mips* mi, 
 	if (mi->op_count == 1)
 	{
 		op0 = loadRegister(MIPS_REG_FCC0, irb); // implied operand
-		op1 = loadOpsUnary(mi, irb);
+		op1 = loadOpUnary(mi, irb);
 	}
 	else if (mi->op_count == 2)
 	{
@@ -556,7 +556,7 @@ void Capstone2LlvmIrTranslatorMips_impl::translateBc1t(cs_insn* i, cs_mips* mi, 
 	if (mi->op_count == 1)
 	{
 		op0 = loadRegister(MIPS_REG_FCC0, irb); // implied operand
-		op1 = loadOpsUnary(mi, irb);
+		op1 = loadOpUnary(mi, irb);
 	}
 	else if (mi->op_count == 2)
 	{
@@ -788,7 +788,7 @@ void Capstone2LlvmIrTranslatorMips_impl::translateBreak(cs_insn* i, cs_mips* mi,
 	}
 	else if (mi->op_count == 1)
 	{
-		op0 = loadOpsUnary(mi, irb);
+		op0 = loadOpUnary(mi, irb);
 	}
 	else if (mi->op_count == 2)
 	{
@@ -1033,7 +1033,7 @@ void Capstone2LlvmIrTranslatorMips_impl::translateJ(cs_insn* i, cs_mips* mi, llv
 {
 	EXPECT_IS_UNARY(i, mi, irb);
 
-	op0 = loadOpsUnary(mi, irb);
+	op0 = loadOpUnary(mi, irb);
 	generateBranchFunctionCall(irb, op0);
 }
 
@@ -1046,7 +1046,7 @@ void Capstone2LlvmIrTranslatorMips_impl::translateJal(cs_insn* i, cs_mips* mi, l
 	EXPECT_IS_UNARY(i, mi, irb);
 
 	storeRegister(MIPS_REG_RA, getNextNextInsnAddress(i), irb);
-	op0 = loadOpsUnary(mi, irb);
+	op0 = loadOpUnary(mi, irb);
 	generateCallFunctionCall(irb, op0);
 }
 
@@ -1464,7 +1464,7 @@ void Capstone2LlvmIrTranslatorMips_impl::translateMthi(cs_insn* i, cs_mips* mi, 
 {
 	EXPECT_IS_UNARY(i, mi, irb);
 
-	op0 = loadOpsUnary(mi, irb);
+	op0 = loadOpUnary(mi, irb);
 	storeRegister(MIPS_REG_HI, op0, irb);
 }
 
@@ -1475,7 +1475,7 @@ void Capstone2LlvmIrTranslatorMips_impl::translateMtlo(cs_insn* i, cs_mips* mi, 
 {
 	EXPECT_IS_UNARY(i, mi, irb);
 
-	op0 = loadOpsUnary(mi, irb);
+	op0 = loadOpUnary(mi, irb);
 	storeRegister(MIPS_REG_LO, op0, irb);
 }
 
@@ -1766,7 +1766,7 @@ void Capstone2LlvmIrTranslatorMips_impl::translateSyscall(cs_insn* i, cs_mips* m
 	}
 	else if (mi->op_count == 1)
 	{
-		op0 = loadOpsUnary(mi, irb);
+		op0 = loadOpUnary(mi, irb);
 	}
 
 	op0 = irb.CreateZExtOrTrunc(op0, getDefaultType());

--- a/src/capstone2llvmir/mips/mips_impl.h
+++ b/src/capstone2llvmir/mips/mips_impl.h
@@ -87,12 +87,12 @@ class Capstone2LlvmIrTranslatorMips_impl :
 				uint32_t r,
 				llvm::Value* val,
 				llvm::IRBuilder<>& irb,
-				eOpConv ct = eOpConv::SEXT_TRUNC) override;
+				eOpConv ct = eOpConv::SEXT_TRUNC_OR_BITCAST) override;
 		virtual llvm::Instruction* storeOp(
 				cs_mips_op& op,
 				llvm::Value* val,
 				llvm::IRBuilder<>& irb,
-				eOpConv ct = eOpConv::SEXT_TRUNC) override;
+				eOpConv ct = eOpConv::SEXT_TRUNC_OR_BITCAST) override;
 
 		llvm::StoreInst* storeRegisterUnpredictable(
 				uint32_t r,

--- a/src/capstone2llvmir/powerpc/powerpc.cpp
+++ b/src/capstone2llvmir/powerpc/powerpc.cpp
@@ -610,7 +610,7 @@ void Capstone2LlvmIrTranslatorPowerpc_impl::translateAdd(cs_insn* i, cs_ppc* pi,
 {
 	EXPECT_IS_BINARY_OR_TERNARY(i, pi, irb);
 
-	std::tie(op1, op2) = loadOpBinaryOrTernaryOp1Op2(pi, irb, eOpConv::SEXT_TRUNC);
+	std::tie(op1, op2) = loadOpBinaryOrTernaryOp1Op2(pi, irb, eOpConv::SEXT_TRUNC_OR_BITCAST, eOpConv::FPCAST_OR_BITCAST);
 	auto* add = irb.CreateAdd(op1, op2);
 	storeOp(pi->operands[0], add, irb);
 	storeCr0(irb, pi, add);
@@ -623,7 +623,7 @@ void Capstone2LlvmIrTranslatorPowerpc_impl::translateAddc(cs_insn* i, cs_ppc* pi
 {
 	EXPECT_IS_BINARY_OR_TERNARY(i, pi, irb);
 
-	std::tie(op1, op2) = loadOpBinaryOrTernaryOp1Op2(pi, irb, eOpConv::SEXT_TRUNC);
+	std::tie(op1, op2) = loadOpBinaryOrTernaryOp1Op2(pi, irb, eOpConv::SEXT_TRUNC_OR_BITCAST);
 	auto* add = irb.CreateAdd(op1, op2);
 	storeOp(pi->operands[0], add, irb);
 	storeCr0(irb, pi, add);
@@ -637,7 +637,7 @@ void Capstone2LlvmIrTranslatorPowerpc_impl::translateAdde(cs_insn* i, cs_ppc* pi
 {
 	EXPECT_IS_BINARY_OR_TERNARY(i, pi, irb);
 
-	std::tie(op1, op2) = loadOpBinaryOrTernaryOp1Op2(pi, irb, eOpConv::SEXT_TRUNC);
+	std::tie(op1, op2) = loadOpBinaryOrTernaryOp1Op2(pi, irb, eOpConv::SEXT_TRUNC_OR_BITCAST);
 	auto* add = irb.CreateAdd(op1, op2);
 	auto* carry = loadRegister(PPC_REG_CARRY, irb);
 	carry = irb.CreateZExtOrTrunc(carry, add->getType());
@@ -656,7 +656,7 @@ void Capstone2LlvmIrTranslatorPowerpc_impl::translateAddis(cs_insn* i, cs_ppc* p
 {
 	EXPECT_IS_BINARY_OR_TERNARY(i, pi, irb);
 
-	std::tie(op1, op2) = loadOpBinaryOrTernaryOp1Op2(pi, irb, eOpConv::ZEXT_TRUNC);
+	std::tie(op1, op2) = loadOpBinaryOrTernaryOp1Op2(pi, irb, eOpConv::ZEXT_TRUNC_OR_BITCAST);
 	op2 = irb.CreateShl(op2, llvm::ConstantInt::get(op2->getType(), 16));
 	auto* add = irb.CreateAdd(op1, op2);
 	storeOp(pi->operands[0], add, irb);
@@ -714,7 +714,7 @@ void Capstone2LlvmIrTranslatorPowerpc_impl::translateAnd(cs_insn* i, cs_ppc* pi,
 {
 	EXPECT_IS_BINARY_OR_TERNARY(i, pi, irb);
 
-	std::tie(op1, op2) = loadOpBinaryOrTernaryOp1Op2(pi, irb, eOpConv::ZEXT_TRUNC);
+	std::tie(op1, op2) = loadOpBinaryOrTernaryOp1Op2(pi, irb, eOpConv::ZEXT_TRUNC_OR_BITCAST);
 	auto* val = irb.CreateAnd(op1, op2);
 	storeOp(pi->operands[0], val, irb);
 	storeCr0(irb, pi, val);
@@ -727,7 +727,7 @@ void Capstone2LlvmIrTranslatorPowerpc_impl::translateAndc(cs_insn* i, cs_ppc* pi
 {
 	EXPECT_IS_BINARY_OR_TERNARY(i, pi, irb);
 
-	std::tie(op1, op2) = loadOpBinaryOrTernaryOp1Op2(pi, irb, eOpConv::ZEXT_TRUNC);
+	std::tie(op1, op2) = loadOpBinaryOrTernaryOp1Op2(pi, irb, eOpConv::ZEXT_TRUNC_OR_BITCAST);
 	op2 = generateValueNegate(irb, op2);
 	auto* val = irb.CreateAnd(op1, op2);
 	storeOp(pi->operands[0], val, irb);
@@ -741,7 +741,7 @@ void Capstone2LlvmIrTranslatorPowerpc_impl::translateAndis(cs_insn* i, cs_ppc* p
 {
 	EXPECT_IS_BINARY_OR_TERNARY(i, pi, irb);
 
-	std::tie(op1, op2) = loadOpBinaryOrTernaryOp1Op2(pi, irb, eOpConv::ZEXT_TRUNC);
+	std::tie(op1, op2) = loadOpBinaryOrTernaryOp1Op2(pi, irb, eOpConv::ZEXT_TRUNC_OR_BITCAST);
 	op2 = irb.CreateShl(op2, llvm::ConstantInt::get(op2->getType(), 16));
 	auto* val = irb.CreateAnd(op1, op2);
 	storeOp(pi->operands[0], val, irb);
@@ -755,7 +755,7 @@ void Capstone2LlvmIrTranslatorPowerpc_impl::translateClrlwi(cs_insn* i, cs_ppc* 
 {
 	EXPECT_IS_BINARY_OR_TERNARY(i, pi, irb);
 
-	std::tie(op1, op2) = loadOpBinaryOrTernaryOp1Op2(pi, irb, eOpConv::ZEXT_TRUNC);
+	std::tie(op1, op2) = loadOpBinaryOrTernaryOp1Op2(pi, irb, eOpConv::ZEXT_TRUNC_OR_BITCAST);
 	op2 = irb.CreateAnd(op2, llvm::ConstantInt::get(op2->getType(), 31));
 	op1 = irb.CreateShl(op1, op2);
 	op1 = irb.CreateLShr(op1, op2);
@@ -782,7 +782,7 @@ void Capstone2LlvmIrTranslatorPowerpc_impl::translateCmp(cs_insn* i, cs_ppc* pi,
 	if (pi->op_count == 2)
 	{
 		crReg = PPC_REG_CR0;
-		std::tie(op0, op1) = loadOpBinary(pi, irb, eOpConv::SEXT_TRUNC);
+		std::tie(op0, op1) = loadOpBinary(pi, irb, eOpConv::SEXT_TRUNC_OR_BITCAST);
 	}
 	else if (pi->op_count == 3
 			&& pi->operands[0].type == PPC_OP_REG
@@ -790,7 +790,7 @@ void Capstone2LlvmIrTranslatorPowerpc_impl::translateCmp(cs_insn* i, cs_ppc* pi,
 			&& pi->operands[0].reg <= PPC_REG_CR7)
 	{
 		crReg = pi->operands[0].reg;
-		std::tie(op0, op1) = loadOpBinaryOrTernaryOp1Op2(pi, irb, eOpConv::SEXT_TRUNC);
+		std::tie(op0, op1) = loadOpBinaryOrTernaryOp1Op2(pi, irb, eOpConv::SEXT_TRUNC_OR_BITCAST);
 	}
 	else
 	{
@@ -857,7 +857,7 @@ void Capstone2LlvmIrTranslatorPowerpc_impl::translateEqv(cs_insn* i, cs_ppc* pi,
 {
 	EXPECT_IS_BINARY_OR_TERNARY(i, pi, irb);
 
-	std::tie(op1, op2) = loadOpBinaryOrTernaryOp1Op2(pi, irb, eOpConv::ZEXT_TRUNC);
+	std::tie(op1, op2) = loadOpBinaryOrTernaryOp1Op2(pi, irb, eOpConv::ZEXT_TRUNC_OR_BITCAST);
 	auto* val = irb.CreateXor(op1, op2);
 	val = generateValueNegate(irb, val);
 	storeOp(pi->operands[0], val, irb);
@@ -924,10 +924,10 @@ void Capstone2LlvmIrTranslatorPowerpc_impl::translateLoad(cs_insn* i, cs_ppc* pi
 
 	op1 = loadOpBinaryOp1(pi, irb, ty);
 
-	eOpConv conv = eOpConv::ZEXT_TRUNC;
+	eOpConv conv = eOpConv::ZEXT_TRUNC_OR_BITCAST;
 	if (i->id == PPC_INS_LHA || i->id == PPC_INS_LHAU)
 	{
-		conv = eOpConv::SEXT_TRUNC;
+		conv = eOpConv::SEXT_TRUNC_OR_BITCAST;
 	}
 	storeOp(pi->operands[0], op1, irb, conv);
 
@@ -953,7 +953,7 @@ void Capstone2LlvmIrTranslatorPowerpc_impl::translateLoadIndexed(cs_insn* i, cs_
 {
 	EXPECT_IS_BINARY_OR_TERNARY(i, pi, irb);
 
-	std::tie(op1, op2) = loadOpBinaryOrTernaryOp1Op2(pi, irb, eOpConv::ZEXT_TRUNC);
+	std::tie(op1, op2) = loadOpBinaryOrTernaryOp1Op2(pi, irb, eOpConv::ZEXT_TRUNC_OR_BITCAST);
 	auto* add = irb.CreateAdd(op1, op2);
 
 	llvm::Type* ty = nullptr;
@@ -981,10 +981,10 @@ void Capstone2LlvmIrTranslatorPowerpc_impl::translateLoadIndexed(cs_insn* i, cs_
 	auto* addr = irb.CreateIntToPtr(add, pty);
 	auto* l = irb.CreateLoad(addr);
 
-	eOpConv conv = eOpConv::ZEXT_TRUNC;
+	eOpConv conv = eOpConv::ZEXT_TRUNC_OR_BITCAST;
 	if (i->id == PPC_INS_LHAX || i->id == PPC_INS_LHAUX)
 	{
-		conv = eOpConv::SEXT_TRUNC;
+		conv = eOpConv::SEXT_TRUNC_OR_BITCAST;
 	}
 	storeOp(pi->operands[0], l, irb, conv);
 
@@ -1106,7 +1106,7 @@ void Capstone2LlvmIrTranslatorPowerpc_impl::translateLhbrx(cs_insn* i, cs_ppc* p
 {
 	EXPECT_IS_BINARY_OR_TERNARY(i, pi, irb);
 
-	std::tie(op1, op2) = loadOpBinaryOrTernaryOp1Op2(pi, irb, eOpConv::ZEXT_TRUNC);
+	std::tie(op1, op2) = loadOpBinaryOrTernaryOp1Op2(pi, irb, eOpConv::ZEXT_TRUNC_OR_BITCAST);
 
 	auto* pty = llvm::PointerType::get(irb.getInt8Ty(), 0);
 
@@ -1123,7 +1123,7 @@ void Capstone2LlvmIrTranslatorPowerpc_impl::translateLhbrx(cs_insn* i, cs_ppc* p
 
 	auto* val = irb.CreateOr(lLo, lHi);
 
-	storeOp(pi->operands[0], val, irb, eOpConv::ZEXT_TRUNC);
+	storeOp(pi->operands[0], val, irb, eOpConv::ZEXT_TRUNC_OR_BITCAST);
 }
 
 /**
@@ -1134,7 +1134,7 @@ void Capstone2LlvmIrTranslatorPowerpc_impl::translateLi(cs_insn* i, cs_ppc* pi, 
 	EXPECT_IS_BINARY(i, pi, irb);
 
 	op1 = loadOpBinaryOp1(pi, irb);
-	storeOp(pi->operands[0], op1, irb, eOpConv::SEXT_TRUNC);
+	storeOp(pi->operands[0], op1, irb, eOpConv::SEXT_TRUNC_OR_BITCAST);
 	storeCr0(irb, pi, op1); // ?
 }
 
@@ -1147,7 +1147,7 @@ void Capstone2LlvmIrTranslatorPowerpc_impl::translateLis(cs_insn* i, cs_ppc* pi,
 
 	op1 = loadOpBinaryOp1(pi, irb);
 	op1 = irb.CreateShl(op1, llvm::ConstantInt::get(op1->getType(), 16));
-	storeOp(pi->operands[0], op1, irb, eOpConv::SEXT_TRUNC);
+	storeOp(pi->operands[0], op1, irb, eOpConv::SEXT_TRUNC_OR_BITCAST);
 	storeCr0(irb, pi, op1); // ?
 }
 
@@ -1203,7 +1203,7 @@ void Capstone2LlvmIrTranslatorPowerpc_impl::translateMtcr(cs_insn* i, cs_ppc* pi
 {
 	EXPECT_IS_UNARY(i, pi, irb);
 
-	op0 = loadOpUnary(pi, irb);
+	op0 = loadOpsUnary(pi, irb);
 	op0 = irb.CreateZExtOrTrunc(op0, irb.getInt32Ty());
 
 	storeRegister(PPC_REG_CR0_LT, irb.CreateAnd(op0, irb.getInt32(1 << 0)), irb);
@@ -1254,7 +1254,7 @@ void Capstone2LlvmIrTranslatorPowerpc_impl::translateMtctr(cs_insn* i, cs_ppc* p
 {
 	EXPECT_IS_UNARY(i, pi, irb);
 
-	op0 = loadOpUnary(pi, irb);
+	op0 = loadOpsUnary(pi, irb);
 	storeRegister(PPC_REG_CTR, op0, irb);
 }
 
@@ -1265,7 +1265,7 @@ void Capstone2LlvmIrTranslatorPowerpc_impl::translateMtlr(cs_insn* i, cs_ppc* pi
 {
 	EXPECT_IS_UNARY(i, pi, irb);
 
-	op0 = loadOpUnary(pi, irb);
+	op0 = loadOpsUnary(pi, irb);
 	storeRegister(PPC_REG_LR, op0, irb);
 }
 
@@ -1502,7 +1502,7 @@ void Capstone2LlvmIrTranslatorPowerpc_impl::translateMullw(cs_insn* i, cs_ppc* p
 {
 	EXPECT_IS_BINARY_OR_TERNARY(i, pi, irb);
 
-	std::tie(op1, op2) = loadOpBinaryOrTernaryOp1Op2(pi, irb, eOpConv::SEXT_TRUNC);
+	std::tie(op1, op2) = loadOpBinaryOrTernaryOp1Op2(pi, irb, eOpConv::SEXT_TRUNC_OR_BITCAST);
 	auto* val = irb.CreateMul(op1, op2);
 	storeOp(pi->operands[0], val, irb);
 	storeCr0(irb, pi, val);
@@ -1515,7 +1515,7 @@ void Capstone2LlvmIrTranslatorPowerpc_impl::translateNand(cs_insn* i, cs_ppc* pi
 {
 	EXPECT_IS_BINARY_OR_TERNARY(i, pi, irb);
 
-	std::tie(op1, op2) = loadOpBinaryOrTernaryOp1Op2(pi, irb, eOpConv::ZEXT_TRUNC);
+	std::tie(op1, op2) = loadOpBinaryOrTernaryOp1Op2(pi, irb, eOpConv::ZEXT_TRUNC_OR_BITCAST);
 	auto* val = irb.CreateAnd(op1, op2);
 	val = generateValueNegate(irb, val);
 	storeOp(pi->operands[0], val, irb);
@@ -1550,7 +1550,7 @@ void Capstone2LlvmIrTranslatorPowerpc_impl::translateNor(cs_insn* i, cs_ppc* pi,
 {
 	EXPECT_IS_BINARY_OR_TERNARY(i, pi, irb);
 
-	std::tie(op1, op2) = loadOpBinaryOrTernaryOp1Op2(pi, irb, eOpConv::ZEXT_TRUNC);
+	std::tie(op1, op2) = loadOpBinaryOrTernaryOp1Op2(pi, irb, eOpConv::ZEXT_TRUNC_OR_BITCAST);
 	auto* val = irb.CreateOr(op1, op2);
 	val = generateValueNegate(irb, val);
 	storeOp(pi->operands[0], val, irb);
@@ -1579,7 +1579,7 @@ void Capstone2LlvmIrTranslatorPowerpc_impl::translateOr(cs_insn* i, cs_ppc* pi, 
 {
 	EXPECT_IS_BINARY_OR_TERNARY(i, pi, irb);
 
-	std::tie(op1, op2) = loadOpBinaryOrTernaryOp1Op2(pi, irb, eOpConv::ZEXT_TRUNC);
+	std::tie(op1, op2) = loadOpBinaryOrTernaryOp1Op2(pi, irb, eOpConv::ZEXT_TRUNC_OR_BITCAST);
 	auto* val = irb.CreateOr(op1, op2);
 	storeOp(pi->operands[0], val, irb);
 	storeCr0(irb, pi, val);
@@ -1592,7 +1592,7 @@ void Capstone2LlvmIrTranslatorPowerpc_impl::translateOrc(cs_insn* i, cs_ppc* pi,
 {
 	EXPECT_IS_BINARY_OR_TERNARY(i, pi, irb);
 
-	std::tie(op1, op2) = loadOpBinaryOrTernaryOp1Op2(pi, irb, eOpConv::ZEXT_TRUNC);
+	std::tie(op1, op2) = loadOpBinaryOrTernaryOp1Op2(pi, irb, eOpConv::ZEXT_TRUNC_OR_BITCAST);
 	op2 = generateValueNegate(irb, op2);
 	auto* val = irb.CreateOr(op1, op2);
 	storeOp(pi->operands[0], val, irb);
@@ -1606,7 +1606,7 @@ void Capstone2LlvmIrTranslatorPowerpc_impl::translateOris(cs_insn* i, cs_ppc* pi
 {
 	EXPECT_IS_BINARY_OR_TERNARY(i, pi, irb);
 
-	std::tie(op1, op2) = loadOpBinaryOrTernaryOp1Op2(pi, irb, eOpConv::ZEXT_TRUNC);
+	std::tie(op1, op2) = loadOpBinaryOrTernaryOp1Op2(pi, irb, eOpConv::ZEXT_TRUNC_OR_BITCAST);
 	op2 = irb.CreateShl(op2, llvm::ConstantInt::get(op2->getType(), 16));
 	auto* val = irb.CreateOr(op1, op2);
 	storeOp(pi->operands[0], val, irb);
@@ -1647,7 +1647,7 @@ void Capstone2LlvmIrTranslatorPowerpc_impl::translateRotlw(cs_insn* i, cs_ppc* p
 {
 	EXPECT_IS_BINARY_OR_TERNARY(i, pi, irb);
 
-	std::tie(op1, op2) = loadOpBinaryOrTernaryOp1Op2(pi, irb, eOpConv::ZEXT_TRUNC);
+	std::tie(op1, op2) = loadOpBinaryOrTernaryOp1Op2(pi, irb, eOpConv::ZEXT_TRUNC_OR_BITCAST);
 	unsigned op0BitW = llvm::cast<llvm::IntegerType>(op1->getType())->getBitWidth();
 	unsigned maskC = op0BitW == 64 ? 0x3f : 0x1f;
 	auto* mask = llvm::ConstantInt::get(op2->getType(), maskC);
@@ -1675,7 +1675,7 @@ void Capstone2LlvmIrTranslatorPowerpc_impl::translateShiftLeft(cs_insn* i, cs_pp
 	op2 = irb.CreateZExtOrTrunc(op2, op1->getType());
 
 	auto* val = irb.CreateShl(op1, op2);
-	storeOp(pi->operands[0], val, irb, eOpConv::ZEXT_TRUNC); // TODO: check it all others are using correct conversion
+	storeOp(pi->operands[0], val, irb, eOpConv::ZEXT_TRUNC_OR_BITCAST); // TODO: check it all others are using correct conversion
 	storeCr0(irb, pi, val);
 }
 
@@ -1692,7 +1692,7 @@ void Capstone2LlvmIrTranslatorPowerpc_impl::translateShiftRight(cs_insn* i, cs_p
 	op2 = irb.CreateZExtOrTrunc(op2, op1->getType());
 
 	auto* val = irb.CreateLShr(op1, op2);
-	storeOp(pi->operands[0], val, irb, eOpConv::ZEXT_TRUNC);
+	storeOp(pi->operands[0], val, irb, eOpConv::ZEXT_TRUNC_OR_BITCAST);
 	storeCr0(irb, pi, val);
 }
 
@@ -1740,7 +1740,7 @@ void Capstone2LlvmIrTranslatorPowerpc_impl::translateSraw(cs_insn* i, cs_ppc* pi
 //	auto* c = irb.CreateCall(fnc, {op1, op2});
 //	op0 = irb.CreateExtractValue(c, {0});
 //
-//	storeOp(pi->operands[0], op0, irb, eOpConv::ZEXT_TRUNC);
+//	storeOp(pi->operands[0], op0, irb, eOpConv::ZEXT_TRUNC_OR_BITCAST);
 //	storeRegister(PPC_REG_CARRY, irb.CreateExtractValue(c, {1}), irb);
 //	storeCr0(irb, pi, op0);
 
@@ -1787,7 +1787,7 @@ void Capstone2LlvmIrTranslatorPowerpc_impl::translateSubf(cs_insn* i, cs_ppc* pi
 {
 	EXPECT_IS_BINARY_OR_TERNARY(i, pi, irb);
 
-	std::tie(op1, op2) = loadOpBinaryOrTernaryOp1Op2(pi, irb, eOpConv::SEXT_TRUNC);
+	std::tie(op1, op2) = loadOpBinaryOrTernaryOp1Op2(pi, irb, eOpConv::SEXT_TRUNC_OR_BITCAST);
 	if (i->id == PPC_INS_SUB)
 	{
 		std::swap(op1, op2);
@@ -1807,7 +1807,7 @@ void Capstone2LlvmIrTranslatorPowerpc_impl::translateSubfc(cs_insn* i, cs_ppc* p
 {
 	EXPECT_IS_BINARY_OR_TERNARY(i, pi, irb);
 
-	std::tie(op1, op2) = loadOpBinaryOrTernaryOp1Op2(pi, irb, eOpConv::SEXT_TRUNC);
+	std::tie(op1, op2) = loadOpBinaryOrTernaryOp1Op2(pi, irb, eOpConv::SEXT_TRUNC_OR_BITCAST);
 	if (i->id == PPC_INS_SUBC)
 	{
 		std::swap(op1, op2);
@@ -1840,7 +1840,7 @@ void Capstone2LlvmIrTranslatorPowerpc_impl::translateSubfe(cs_insn* i, cs_ppc* p
 {
 	EXPECT_IS_BINARY_OR_TERNARY(i, pi, irb);
 
-	std::tie(op1, op2) = loadOpBinaryOrTernaryOp1Op2(pi, irb, eOpConv::SEXT_TRUNC);
+	std::tie(op1, op2) = loadOpBinaryOrTernaryOp1Op2(pi, irb, eOpConv::SEXT_TRUNC_OR_BITCAST);
 	auto* op1Neg = generateValueNegate(irb, op1);
 	auto* val = irb.CreateAdd(op1Neg, op2);
 	auto* carry = loadRegister(PPC_REG_CARRY, irb);
@@ -1903,7 +1903,7 @@ void Capstone2LlvmIrTranslatorPowerpc_impl::translateXor(cs_insn* i, cs_ppc* pi,
 {
 	EXPECT_IS_BINARY_OR_TERNARY(i, pi, irb);
 
-	std::tie(op1, op2) = loadOpBinaryOrTernaryOp1Op2(pi, irb, eOpConv::ZEXT_TRUNC);
+	std::tie(op1, op2) = loadOpBinaryOrTernaryOp1Op2(pi, irb, eOpConv::ZEXT_TRUNC_OR_BITCAST);
 	auto* val = irb.CreateXor(op1, op2);
 	storeOp(pi->operands[0], val, irb);
 	storeCr0(irb, pi, val);
@@ -1916,7 +1916,7 @@ void Capstone2LlvmIrTranslatorPowerpc_impl::translateXoris(cs_insn* i, cs_ppc* p
 {
 	EXPECT_IS_BINARY_OR_TERNARY(i, pi, irb);
 
-	std::tie(op1, op2) = loadOpBinaryOrTernaryOp1Op2(pi, irb, eOpConv::ZEXT_TRUNC);
+	std::tie(op1, op2) = loadOpBinaryOrTernaryOp1Op2(pi, irb, eOpConv::ZEXT_TRUNC_OR_BITCAST);
 	op2 = irb.CreateShl(op2, llvm::ConstantInt::get(op2->getType(), 16));
 	auto* val = irb.CreateXor(op1, op2);
 	storeOp(pi->operands[0], val, irb);
@@ -2225,7 +2225,7 @@ void Capstone2LlvmIrTranslatorPowerpc_impl::translateB(cs_insn* i, cs_ppc* pi, l
 				&& pi->operands[0].type == PPC_OP_IMM)
 		{
 			crReg = PPC_REG_CR0;
-			target = loadOpUnary(pi, irb);
+			target = loadOpsUnary(pi, irb);
 		}
 		else if (pi->op_count == 2
 				&& pi->operands[0].type == PPC_OP_CRX

--- a/src/capstone2llvmir/powerpc/powerpc.cpp
+++ b/src/capstone2llvmir/powerpc/powerpc.cpp
@@ -1203,7 +1203,7 @@ void Capstone2LlvmIrTranslatorPowerpc_impl::translateMtcr(cs_insn* i, cs_ppc* pi
 {
 	EXPECT_IS_UNARY(i, pi, irb);
 
-	op0 = loadOpsUnary(pi, irb);
+	op0 = loadOpUnary(pi, irb);
 	op0 = irb.CreateZExtOrTrunc(op0, irb.getInt32Ty());
 
 	storeRegister(PPC_REG_CR0_LT, irb.CreateAnd(op0, irb.getInt32(1 << 0)), irb);
@@ -1254,7 +1254,7 @@ void Capstone2LlvmIrTranslatorPowerpc_impl::translateMtctr(cs_insn* i, cs_ppc* p
 {
 	EXPECT_IS_UNARY(i, pi, irb);
 
-	op0 = loadOpsUnary(pi, irb);
+	op0 = loadOpUnary(pi, irb);
 	storeRegister(PPC_REG_CTR, op0, irb);
 }
 
@@ -1265,7 +1265,7 @@ void Capstone2LlvmIrTranslatorPowerpc_impl::translateMtlr(cs_insn* i, cs_ppc* pi
 {
 	EXPECT_IS_UNARY(i, pi, irb);
 
-	op0 = loadOpsUnary(pi, irb);
+	op0 = loadOpUnary(pi, irb);
 	storeRegister(PPC_REG_LR, op0, irb);
 }
 
@@ -2225,7 +2225,7 @@ void Capstone2LlvmIrTranslatorPowerpc_impl::translateB(cs_insn* i, cs_ppc* pi, l
 				&& pi->operands[0].type == PPC_OP_IMM)
 		{
 			crReg = PPC_REG_CR0;
-			target = loadOpsUnary(pi, irb);
+			target = loadOpUnary(pi, irb);
 		}
 		else if (pi->op_count == 2
 				&& pi->operands[0].type == PPC_OP_CRX

--- a/src/capstone2llvmir/powerpc/powerpc_impl.h
+++ b/src/capstone2llvmir/powerpc/powerpc_impl.h
@@ -71,12 +71,12 @@ class Capstone2LlvmIrTranslatorPowerpc_impl :
 				uint32_t r,
 				llvm::Value* val,
 				llvm::IRBuilder<>& irb,
-				eOpConv ct = eOpConv::SEXT_TRUNC) override;
+				eOpConv ct = eOpConv::SEXT_TRUNC_OR_BITCAST) override;
 		virtual llvm::Instruction* storeOp(
 				cs_ppc_op& op,
 				llvm::Value* val,
 				llvm::IRBuilder<>& irb,
-				eOpConv ct = eOpConv::SEXT_TRUNC) override;
+				eOpConv ct = eOpConv::SEXT_TRUNC_OR_BITCAST) override;
 
 		void storeCrX(
 				llvm::IRBuilder<>& irb,

--- a/src/capstone2llvmir/x86/x86.cpp
+++ b/src/capstone2llvmir/x86/x86.cpp
@@ -1276,7 +1276,7 @@ Capstone2LlvmIrTranslatorX86_impl::loadOpFloatingNullaryOrUnaryTop(
 	{
 		if (i->id == X86_INS_FILD)
 		{
-			op0 = loadOpsUnary(
+			op0 = loadOpUnary(
 					xi,
 					irb,
 					nullptr,
@@ -1286,7 +1286,7 @@ Capstone2LlvmIrTranslatorX86_impl::loadOpFloatingNullaryOrUnaryTop(
 		// X86_INS_FLD
 		else
 		{
-			op0 = loadOpsUnary(
+			op0 = loadOpUnary(
 					xi,
 					irb,
 					llvm::Type::getFloatTy(_module->getContext()),
@@ -1370,7 +1370,7 @@ Capstone2LlvmIrTranslatorX86_impl::loadOpFloatingBinaryTop(
 				|| i->id == X86_INS_FISUBR)
 		{
 			op0 = loadX87DataReg(irb, top);
-			op1 = loadOpsUnary(
+			op1 = loadOpUnary(
 					xi,
 					irb,
 					nullptr,
@@ -1381,7 +1381,7 @@ Capstone2LlvmIrTranslatorX86_impl::loadOpFloatingBinaryTop(
 				|| i->id == X86_INS_FICOMP)
 		{
 			op0 = loadX87DataReg(irb, top);
-			op1 = loadOpsUnary(
+			op1 = loadOpUnary(
 					xi,
 					irb,
 					nullptr,
@@ -1391,7 +1391,7 @@ Capstone2LlvmIrTranslatorX86_impl::loadOpFloatingBinaryTop(
 		else
 		{
 			op0 = loadX87DataReg(irb, top);
-			op1 = loadOpsUnary(
+			op1 = loadOpUnary(
 					xi,
 					irb,
 					llvm::Type::getFloatTy(_module->getContext()),
@@ -1766,7 +1766,7 @@ void Capstone2LlvmIrTranslatorX86_impl::translateAad(cs_insn* i, cs_x86* xi, llv
 	}
 	else
 	{
-		op0 = loadOpsUnary(xi, irb, nullptr, ah->getType(), eOpConv::ZEXT_TRUNC_OR_BITCAST);
+		op0 = loadOpUnary(xi, irb, nullptr, ah->getType(), eOpConv::ZEXT_TRUNC_OR_BITCAST);
 	}
 
 	auto* mul = irb.CreateMul(ah, op0);
@@ -1793,7 +1793,7 @@ void Capstone2LlvmIrTranslatorX86_impl::translateAam(cs_insn* i, cs_x86* xi, llv
 	}
 	else
 	{
-		op0 = loadOpsUnary(xi, irb, nullptr, al->getType(), eOpConv::ZEXT_TRUNC_OR_BITCAST);
+		op0 = loadOpUnary(xi, irb, nullptr, al->getType(), eOpConv::ZEXT_TRUNC_OR_BITCAST);
 	}
 
 	auto* div = irb.CreateUDiv(al, op0);
@@ -1914,7 +1914,7 @@ void Capstone2LlvmIrTranslatorX86_impl::translateBswap(cs_insn* i, cs_x86* xi, l
 {
 	EXPECT_IS_UNARY(i, xi, irb);
 
-	op0 = loadOpsUnary(xi, irb);
+	op0 = loadOpUnary(xi, irb);
 	auto* f = llvm::Intrinsic::getDeclaration(
 			_module,
 			llvm::Intrinsic::bswap,
@@ -2157,7 +2157,7 @@ void Capstone2LlvmIrTranslatorX86_impl::translateCmpxchg8b(cs_insn* i, cs_x86* x
 {
 	EXPECT_IS_UNARY(i, xi, irb);
 
-	op0 = loadOpsUnary(xi, irb);
+	op0 = loadOpUnary(xi, irb);
 	auto* eax = loadRegister(X86_REG_EAX, irb, op0->getType(), eOpConv::ZEXT_TRUNC_OR_BITCAST);
 	auto* edx = loadRegister(X86_REG_EDX, irb, op0->getType(), eOpConv::ZEXT_TRUNC_OR_BITCAST);
 	edx = irb.CreateShl(edx, 32);
@@ -2188,7 +2188,7 @@ void Capstone2LlvmIrTranslatorX86_impl::translateCmpxchg16b(cs_insn* i, cs_x86* 
 {
 	EXPECT_IS_UNARY(i, xi, irb);
 
-	op0 = loadOpsUnary(xi, irb);
+	op0 = loadOpUnary(xi, irb);
 	auto* rax = loadRegister(X86_REG_RAX, irb, op0->getType(), eOpConv::ZEXT_TRUNC_OR_BITCAST);
 	auto* rdx = loadRegister(X86_REG_RDX, irb, op0->getType(), eOpConv::ZEXT_TRUNC_OR_BITCAST);
 	rdx = irb.CreateShl(rdx, 64);
@@ -2219,7 +2219,7 @@ void Capstone2LlvmIrTranslatorX86_impl::translateDec(cs_insn* i, cs_x86* xi, llv
 {
 	EXPECT_IS_UNARY(i, xi, irb);
 
-	op0 = loadOpsUnary(xi, irb);
+	op0 = loadOpUnary(xi, irb);
 	op1 = llvm::ConstantInt::get(op0->getType(), 1);
 
 	auto* sub = irb.CreateSub(op0, op1);
@@ -2288,7 +2288,7 @@ void Capstone2LlvmIrTranslatorX86_impl::translateInc(cs_insn* i, cs_x86* xi, llv
 {
 	EXPECT_IS_UNARY(i, xi, irb);
 
-	op0 = loadOpsUnary(xi, irb);
+	op0 = loadOpUnary(xi, irb);
 	op1 = llvm::ConstantInt::get(op0->getType(), 1);
 
 	auto* add = irb.CreateAdd(op0, op1);
@@ -2307,7 +2307,7 @@ void Capstone2LlvmIrTranslatorX86_impl::translateDiv(cs_insn* i, cs_x86* xi, llv
 {
 	EXPECT_IS_UNARY(i, xi, irb);
 
-	op1 = loadOpsUnary(xi, irb);
+	op1 = loadOpUnary(xi, irb);
 	uint32_t op0l = X86_REG_INVALID;
 	uint32_t op0h = X86_REG_INVALID;
 	uint32_t divR = X86_REG_INVALID;
@@ -2396,7 +2396,7 @@ void Capstone2LlvmIrTranslatorX86_impl::translateJmp(cs_insn* i, cs_x86* xi, llv
 {
 	EXPECT_IS_UNARY(i, xi, irb);
 
-	op0 = loadOpsUnary(xi, irb);
+	op0 = loadOpUnary(xi, irb);
 	generateBranchFunctionCall(irb, op0);
 }
 
@@ -2456,7 +2456,7 @@ void Capstone2LlvmIrTranslatorX86_impl::translateCall(cs_insn* i, cs_x86* xi, ll
 	irb.CreateStore(pc, addr);
 	storeRegister(getStackPointerRegister(), sub, irb);
 
-	op0 = loadOpsUnary(xi, irb);
+	op0 = loadOpUnary(xi, irb);
 	generateCallFunctionCall(irb, op0);
 }
 
@@ -2488,7 +2488,7 @@ void Capstone2LlvmIrTranslatorX86_impl::translateLcall(cs_insn* i, cs_x86* xi, l
 
 	if (xi->op_count == 1)
 	{
-		op0 = loadOpsUnary(xi, irb);
+		op0 = loadOpUnary(xi, irb);
 	}
 	// binary e.g.: lcall 7:0
 	else
@@ -2659,7 +2659,7 @@ void Capstone2LlvmIrTranslatorX86_impl::translateMul(cs_insn* i, cs_x86* xi, llv
 {
 	EXPECT_IS_UNARY(i, xi, irb);
 
-	op0 = loadOpsUnary(xi, irb);
+	op0 = loadOpUnary(xi, irb);
 	op1 = loadRegister(getAccumulatorRegister(xi->operands[0].size), irb);
 
 	llvm::IntegerType* halfT = nullptr;
@@ -2737,7 +2737,7 @@ void Capstone2LlvmIrTranslatorX86_impl::translateNeg(cs_insn* i, cs_x86* xi, llv
 {
 	EXPECT_IS_UNARY(i, xi, irb);
 
-	op0 = loadOpsUnary(xi, irb);
+	op0 = loadOpUnary(xi, irb);
 	auto* zero = llvm::ConstantInt::get(op0->getType(), 0);
 
 	auto* sub = irb.CreateSub(zero, op0);
@@ -2834,7 +2834,7 @@ void Capstone2LlvmIrTranslatorX86_impl::translateNot(cs_insn* i, cs_x86* xi, llv
 {
 	EXPECT_IS_UNARY(i, xi, irb);
 
-	op0 = loadOpsUnary(xi, irb);
+	op0 = loadOpUnary(xi, irb);
 	auto* negativeOne = llvm::ConstantInt::getSigned(op0->getType(), -1);
 
 	auto* xorOp = irb.CreateXor(op0, negativeOne);
@@ -3012,7 +3012,7 @@ void Capstone2LlvmIrTranslatorX86_impl::translatePush(cs_insn* i, cs_x86* xi, ll
 {
 	EXPECT_IS_UNARY(i, xi, irb);
 
-	op0 = loadOpsUnary(xi, irb);
+	op0 = loadOpUnary(xi, irb);
 	auto* sp = loadRegister(getStackPointerRegister(), irb);
 
 	auto* ci = llvm::ConstantInt::get(sp->getType(), xi->operands[0].size);
@@ -3175,7 +3175,7 @@ void Capstone2LlvmIrTranslatorX86_impl::translateRet(cs_insn* i, cs_x86* xi, llv
 	op0 = nullptr;
 	if (xi->op_count == 1)
 	{
-		op0 = loadOpsUnary(xi, irb);
+		op0 = loadOpUnary(xi, irb);
 	}
 
 	auto* it = getIntegerTypeFromByteSize(_module, sz);
@@ -4153,7 +4153,7 @@ void Capstone2LlvmIrTranslatorX86_impl::translateJecxz(cs_insn* i, cs_x86* xi, l
 	}
 
 	auto* eqZ = irb.CreateICmpEQ(ecx, llvm::ConstantInt::get(ecx->getType(), 0));
-	op0 = loadOpsUnary(xi, irb);
+	op0 = loadOpUnary(xi, irb);
 	generateCondBranchFunctionCall(irb, eqZ, op0);
 }
 
@@ -4206,7 +4206,7 @@ void Capstone2LlvmIrTranslatorX86_impl::translateLoop(cs_insn* i, cs_x86* xi, ll
 		}
 	}
 
-	op0 = loadOpsUnary(xi, irb);
+	op0 = loadOpUnary(xi, irb);
 	generateCondBranchFunctionCall(irb, cnd, op0);
 }
 
@@ -4241,7 +4241,7 @@ void Capstone2LlvmIrTranslatorX86_impl::translateJCc(cs_insn* i, cs_x86* xi, llv
 		default: throw GenericError("Unhandled insn ID in translateJCc().");
 	}
 
-	op0 = loadOpsUnary(xi, irb);
+	op0 = loadOpUnary(xi, irb);
 	generateCondBranchFunctionCall(irb, cond, op0);
 }
 

--- a/src/capstone2llvmir/x86/x86_impl.h
+++ b/src/capstone2llvmir/x86/x86_impl.h
@@ -120,12 +120,12 @@ class Capstone2LlvmIrTranslatorX86_impl :
 				uint32_t r,
 				llvm::Value* val,
 				llvm::IRBuilder<>& irb,
-				eOpConv ct = eOpConv::ZEXT_TRUNC) override;
+				eOpConv ct = eOpConv::ZEXT_TRUNC_OR_BITCAST) override;
 		virtual llvm::Instruction* storeOp(
 				cs_x86_op& op,
 				llvm::Value* val,
 				llvm::IRBuilder<>& irb,
-				eOpConv ct = eOpConv::ZEXT_TRUNC) override;
+				eOpConv ct = eOpConv::ZEXT_TRUNC_OR_BITCAST) override;
 
 		void storeRegisters(
 				llvm::IRBuilder<>& irb,

--- a/tests/capstone2llvmir/CMakeLists.txt
+++ b/tests/capstone2llvmir/CMakeLists.txt
@@ -1,12 +1,22 @@
-set(RETDEC_TESTS_CAPSTONE2LLVMIR_SOURCES
-	arm_tests.cpp
-	arm64_tests.cpp
-	mips_tests.cpp
-	powerpc_tests.cpp
-	x86_tests.cpp
-)
 
-add_executable(retdec-tests-capstone2llvmir ${RETDEC_TESTS_CAPSTONE2LLVMIR_SOURCES})
-target_link_libraries(retdec-tests-capstone2llvmir retdec-capstone2llvmir retdec-llvmir-emul keystone gmock_main)
-target_include_directories(retdec-tests-capstone2llvmir PUBLIC ${PROJECT_SOURCE_DIR}/tests/)
-install(TARGETS retdec-tests-capstone2llvmir RUNTIME DESTINATION ${RETDEC_TESTS_DIR})
+add_executable(retdec-tests-capstone2llvmir
+		arm_tests.cpp
+		arm64_tests.cpp
+		mips_tests.cpp
+		powerpc_tests.cpp
+		x86_tests.cpp
+)
+target_link_libraries(retdec-tests-capstone2llvmir
+		retdec-capstone2llvmir
+		retdec-llvmir-emul
+		retdec-utils
+		keystone
+		gmock_main
+)
+target_include_directories(retdec-tests-capstone2llvmir
+	PUBLIC
+		${PROJECT_SOURCE_DIR}/tests/
+)
+install(TARGETS retdec-tests-capstone2llvmir
+	RUNTIME DESTINATION ${RETDEC_TESTS_DIR}
+)

--- a/tests/capstone2llvmir/arm64_tests.cpp
+++ b/tests/capstone2llvmir/arm64_tests.cpp
@@ -360,6 +360,20 @@ TEST_P(Capstone2LlvmIrTranslatorArm64Tests, ARM64_INS_ADD_r_r_i)
 	EXPECT_NO_VALUE_CALLED();
 }
 
+TEST_P(Capstone2LlvmIrTranslatorArm64Tests, ARM64_INS_ADD_r_r_i_bin)
+{
+	setRegisters({
+		{ARM64_REG_X1, 0x1230},
+	});
+
+	emulate_bin("20 0c 00 91");
+
+	EXPECT_JUST_REGISTERS_LOADED({ARM64_REG_X1});
+	EXPECT_JUST_REGISTERS_STORED({{ARM64_REG_X0, 0x1233},});
+	EXPECT_NO_MEMORY_LOADED_STORED();
+	EXPECT_NO_VALUE_CALLED();
+}
+
 TEST_P(Capstone2LlvmIrTranslatorArm64Tests, ARM64_INS_ADD32_r_r_i)
 {
 	setRegisters({

--- a/tests/capstone2llvmir/arm_tests.cpp
+++ b/tests/capstone2llvmir/arm_tests.cpp
@@ -117,6 +117,24 @@ TEST_P(Capstone2LlvmIrTranslatorArmTests, ARM_INS_ADD_r_r_i)
 	EXPECT_NO_VALUE_CALLED();
 }
 
+TEST_P(Capstone2LlvmIrTranslatorArmTests, ARM_INS_ADD_r_r_i_bin)
+{
+	ONLY_MODE_ARM;
+
+	setRegisters({
+		{ARM_REG_R1, 0x1230},
+	});
+
+	emulate_bin("04 00 81 e2");
+
+	EXPECT_JUST_REGISTERS_LOADED({ARM_REG_R1});
+	EXPECT_JUST_REGISTERS_STORED({
+		{ARM_REG_R0, 0x1234},
+	});
+	EXPECT_NO_MEMORY_LOADED_STORED();
+	EXPECT_NO_VALUE_CALLED();
+}
+
 TEST_P(Capstone2LlvmIrTranslatorArmTests, ARM_INS_ADD_r_i)
 {
 	ALL_MODES;

--- a/tests/capstone2llvmir/mips_tests.cpp
+++ b/tests/capstone2llvmir/mips_tests.cpp
@@ -132,6 +132,25 @@ TEST_P(Capstone2LlvmIrTranslatorMipsTests, MIPS_INS_ADDIU_3_op)
 	EXPECT_NO_VALUE_CALLED();
 }
 
+TEST_P(Capstone2LlvmIrTranslatorMipsTests, MIPS_INS_ADDIU_3_op_bin)
+{
+	ONLY_MODE_32;
+
+	setRegisters({
+		{MIPS_REG_1, 0x1234},
+		{MIPS_REG_2, 0x5678},
+	});
+
+	emulate_bin("00 10 41 24");
+
+	EXPECT_JUST_REGISTERS_LOADED({MIPS_REG_2});
+	EXPECT_JUST_REGISTERS_STORED({
+		{MIPS_REG_1, 0x6678},
+	});
+	EXPECT_NO_MEMORY_LOADED_STORED();
+	EXPECT_NO_VALUE_CALLED();
+}
+
 TEST_P(Capstone2LlvmIrTranslatorMipsTests, MIPS_INS_ADDIU_2_op)
 {
 	ALL_MODES;

--- a/tests/capstone2llvmir/mips_tests.cpp
+++ b/tests/capstone2llvmir/mips_tests.cpp
@@ -6107,6 +6107,30 @@ TEST_P(Capstone2LlvmIrTranslatorMipsTests, MIPS_INS_C_ule_d_32)
 	EXPECT_NO_VALUE_CALLED();
 }
 
+//
+//==============================================================================
+// Issue unit tests.
+//==============================================================================
+//
+
+TEST_P(Capstone2LlvmIrTranslatorMipsTests, issue_633)
+{
+	ONLY_MODE_32;
+
+	setRegisters({
+		{MIPS_REG_W31, 3.14_f64},
+	});
+
+	emulate_bin("c0 ff b7 79"); // ori.b $w31, $w31, 0xb7
+
+	EXPECT_JUST_REGISTERS_LOADED({MIPS_REG_W31});
+	EXPECT_JUST_REGISTERS_STORED({
+		{MIPS_REG_W31, ANY},
+	});
+	EXPECT_NO_MEMORY_LOADED_STORED();
+	EXPECT_NO_VALUE_CALLED();
+}
+
 } // namespace tests
 } // namespace capstone2llvmir
 } // namespace retdec

--- a/tests/capstone2llvmir/powerpc_tests.cpp
+++ b/tests/capstone2llvmir/powerpc_tests.cpp
@@ -125,6 +125,25 @@ TEST_P(Capstone2LlvmIrTranslatorPowerpcTests, PPC_INS_ADD)
 	EXPECT_NO_VALUE_CALLED();
 }
 
+TEST_P(Capstone2LlvmIrTranslatorPowerpcTests, PPC_INS_ADD_bin)
+{
+	ONLY_MODE_32;
+
+	setRegisters({
+		{PPC_REG_R0, 0x1111},
+		{PPC_REG_R1, 0x2222},
+	});
+
+	emulate_bin("7c 00 0a 14");
+
+	EXPECT_JUST_REGISTERS_LOADED({PPC_REG_R0, PPC_REG_R1});
+	EXPECT_JUST_REGISTERS_STORED({
+		{PPC_REG_R0, 0x3333},
+	});
+	EXPECT_NO_MEMORY_LOADED_STORED();
+	EXPECT_NO_VALUE_CALLED();
+}
+
 TEST_P(Capstone2LlvmIrTranslatorPowerpcTests, PPC_INS_ADD_dot_zero)
 {
 	ALL_MODES;

--- a/tests/capstone2llvmir/x86_tests.cpp
+++ b/tests/capstone2llvmir/x86_tests.cpp
@@ -1054,6 +1054,31 @@ TEST_P(Capstone2LlvmIrTranslatorX86Tests, X86_INS_ADD_reg32_reg32)
 	EXPECT_NO_VALUE_CALLED();
 }
 
+TEST_P(Capstone2LlvmIrTranslatorX86Tests, X86_INS_ADD_reg32_reg32_bin)
+{
+	ONLY_MODE_32;
+
+	setRegisters({
+		{X86_REG_EAX, 0x12340000},
+		{X86_REG_ECX, 0x00005678},
+	});
+
+	emulate_bin("01 c8");
+
+	EXPECT_JUST_REGISTERS_LOADED({X86_REG_EAX, X86_REG_ECX});
+	EXPECT_JUST_REGISTERS_STORED({
+		{X86_REG_EAX, 0x12345678},
+		{X86_REG_PF, true},
+		{X86_REG_SF, false},
+		{X86_REG_ZF, false},
+		{X86_REG_OF, false},
+		{X86_REG_AF, false},
+		{X86_REG_CF, false},
+	});
+	EXPECT_NO_MEMORY_LOADED_STORED();
+	EXPECT_NO_VALUE_CALLED();
+}
+
 TEST_P(Capstone2LlvmIrTranslatorX86Tests, X86_INS_ADD_reg64_imm32)
 {
 	ONLY_MODE_64;


### PR DESCRIPTION
Redesigns `loadOp` methods that are responsible for the loading of operands of instructions.
Before this PR it was possible to load operands of incompatible type for the instruction which did
result in faulty decompilation. This PR tries to bring changes that will ensure that operands are
converted with a proper method before usage.
