### PR TITLE
Allow building against pog on 64-bit Linux machines

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,9 @@
 cmake_minimum_required(VERSION 3.6)
 
 project(retdec C CXX)
+
+include(GNUInstallDirs)
+
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)

--- a/deps/yaramod/CMakeLists.txt
+++ b/deps/yaramod/CMakeLists.txt
@@ -73,12 +73,12 @@ target_include_directories(yaramod SYSTEM INTERFACE ${binary_dir}/deps/pog/pog-i
 target_link_libraries(yaramod
 	INTERFACE debug
 		${binary_dir}/src/${DEBUG_DIR}${CMAKE_STATIC_LIBRARY_PREFIX}yaramod${CMAKE_STATIC_LIBRARY_SUFFIX}
-		${binary_dir}/deps/pog/pog-install/lib/${CMAKE_STATIC_LIBRARY_PREFIX}pog_fmt${CMAKE_STATIC_LIBRARY_SUFFIX}
-		${binary_dir}/deps/pog/pog-install/lib/${CMAKE_STATIC_LIBRARY_PREFIX}pog_re2${CMAKE_STATIC_LIBRARY_SUFFIX}
+		${binary_dir}/deps/pog/pog-install/${CMAKE_INSTALL_LIBDIR}/${CMAKE_STATIC_LIBRARY_PREFIX}pog_fmt${CMAKE_STATIC_LIBRARY_SUFFIX}
+		${binary_dir}/deps/pog/pog-install/${CMAKE_INSTALL_LIBDIR}/${CMAKE_STATIC_LIBRARY_PREFIX}pog_re2${CMAKE_STATIC_LIBRARY_SUFFIX}
 )
 target_link_libraries(yaramod
 	INTERFACE optimized
 		${binary_dir}/src/${RELEASE_DIR}${CMAKE_STATIC_LIBRARY_PREFIX}yaramod${CMAKE_STATIC_LIBRARY_SUFFIX}
-		${binary_dir}/deps/pog/pog-install/lib/${CMAKE_STATIC_LIBRARY_PREFIX}pog_fmt${CMAKE_STATIC_LIBRARY_SUFFIX}
-		${binary_dir}/deps/pog/pog-install/lib/${CMAKE_STATIC_LIBRARY_PREFIX}pog_re2${CMAKE_STATIC_LIBRARY_SUFFIX}
+		${binary_dir}/deps/pog/pog-install/${CMAKE_INSTALL_LIBDIR}/${CMAKE_STATIC_LIBRARY_PREFIX}pog_fmt${CMAKE_STATIC_LIBRARY_SUFFIX}
+		${binary_dir}/deps/pog/pog-install/${CMAKE_INSTALL_LIBDIR}/${CMAKE_STATIC_LIBRARY_PREFIX}pog_re2${CMAKE_STATIC_LIBRARY_SUFFIX}
 )


### PR DESCRIPTION
Current master will fail to build on 64-bit Linux machines due to looking for `libpog_fmt.a` at `external/src/yaramod-project-build/deps/pog/pog-install/lib/libpog_fmt.a` whereas, due to `include(GNUInstallDirs)` in the pog cmake config, the file will be located at `external/src/yaramod-project-build/deps/pog/pog-install/lib64/libpog_fmt.a`. This can be solved by adding the `include` statement (already present in `yaramod`) and using `CMAKE_INSTALL_LIBDIR` in the pog path.