### PR TITLE
Request to provide new function type

### DIFF
--- a/include/retdec/common/function.h
+++ b/include/retdec/common/function.h
@@ -35,9 +35,23 @@ using LineNumber = retdec::common::Address;
 class Function : public retdec::common::AddressRange
 {
 	public:
+		/**
+		 * Recognized types of a function that will determine
+		 * how the decompiler will treat the specified function.
+		 *
+		 * When the type is DECOMPILER_DEFINED the decompiler is
+		 * allowed to prefer info recieved from some heuristics,
+		 * instead of info specified in the config.
+		 *
+		 * When the type is USER_DEFINED the info about the function
+		 * (params, type) specified in a config file will be projected
+		 * on the decompiler output and the decompiler should not do
+		 * any heuristcs.
+		 */
 		enum eLinkType
 		{
-			USER_DEFINED = 0,
+			DECOMPILER_DEFINED = 0,
+			USER_DEFINED,
 			STATICALLY_LINKED,
 			DYNAMICALLY_LINKED,
 			SYSCALL,
@@ -53,6 +67,7 @@ class Function : public retdec::common::AddressRange
 
 		/// @name Function query methods.
 		/// @{
+		bool isDecompilerDefined() const;
 		bool isUserDefined() const;
 		bool isStaticallyLinked() const;
 		bool isDynamicallyLinked() const;
@@ -80,6 +95,7 @@ class Function : public retdec::common::AddressRange
 		void setWrappedFunctionName(const std::string& n);
 		void setStartLine(const retdec::common::Address& l);
 		void setEndLine(const retdec::common::Address& l);
+		void setIsDecompilerDefined();
 		void setIsUserDefined();
 		void setIsStaticallyLinked() const;
 		void setIsDynamicallyLinked() const;
@@ -134,7 +150,7 @@ class Function : public retdec::common::AddressRange
 		std::string _declarationString;
 		std::string _sourceFileName;
 		std::string _wrapperdFunctionName;
-		mutable eLinkType _linkType = USER_DEFINED;
+		mutable eLinkType _linkType = DECOMPILER_DEFINED;
 		LineNumber _startLine;
 		LineNumber _endLine;
 		bool _fromDebug = false;

--- a/include/retdec/llvmir2hll/config/config.h
+++ b/include/retdec/llvmir2hll/config/config.h
@@ -134,6 +134,11 @@ public:
 	virtual LineRange getLineRangeForFunc(const std::string &func) const = 0;
 
 	/**
+	* @brief Is the given function decompiler-defined?
+	*/
+	virtual bool isDecompilerDefinedFunc(const std::string &func) const = 0;
+
+	/**
 	* @brief Is the given function user-defined?
 	*/
 	virtual bool isUserDefinedFunc(const std::string &func) const = 0;

--- a/include/retdec/llvmir2hll/config/configs/json_config.h
+++ b/include/retdec/llvmir2hll/config/configs/json_config.h
@@ -70,6 +70,7 @@ public:
 	virtual std::string getRealNameForFunc(const std::string &func) const override;
 	virtual AddressRange getAddressRangeForFunc(const std::string &func) const override;
 	virtual LineRange getLineRangeForFunc(const std::string &func) const override;
+	virtual bool isDecompilerDefinedFunc(const std::string &func) const override;
 	virtual bool isUserDefinedFunc(const std::string &func) const override;
 	virtual bool isStaticallyLinkedFunc(const std::string &func) const override;
 	virtual bool isDynamicallyLinkedFunc(const std::string &func) const override;

--- a/include/retdec/llvmir2hll/ir/module.h
+++ b/include/retdec/llvmir2hll/ir/module.h
@@ -92,6 +92,9 @@ public:
 	std::size_t getNumOfFuncDefinitions() const;
 	bool hasFuncDefinitions() const;
 
+	bool hasDecompilerDefinedFuncs() const;
+	FuncSet getDecompilerDefinedFuncs() const;
+
 	bool hasUserDefinedFuncs() const;
 	FuncSet getUserDefinedFuncs() const;
 

--- a/src/bin2llvmir/optimizations/dsm_generator/dsm_generator.cpp
+++ b/src/bin2llvmir/optimizations/dsm_generator/dsm_generator.cpp
@@ -225,7 +225,7 @@ void DsmGenerator::generateFunction(
 			<< fnc->getStart().toHexPrefixString()
 			<< " -- " << fnc->getEnd().toHexPrefixString() << "\n";
 
-	if (!fnc->isUserDefined())
+	if (!fnc->isDecompilerDefined() && !fnc->isUserDefined())
 	{
 		return;
 	}

--- a/src/common/function.cpp
+++ b/src/common/function.cpp
@@ -37,6 +37,7 @@ Function::Function(
 
 }
 
+bool Function::isDecompilerDefined() const { return _linkType == DECOMPILER_DEFINED; }
 bool Function::isUserDefined() const       { return _linkType == USER_DEFINED; }
 bool Function::isStaticallyLinked() const  { return _linkType == STATICALLY_LINKED; }
 bool Function::isDynamicallyLinked() const { return _linkType == DYNAMICALLY_LINKED; }
@@ -68,6 +69,7 @@ void Function::setSourceFileName(const std::string& n)      { _sourceFileName = 
 void Function::setWrappedFunctionName(const std::string& n) { _wrapperdFunctionName = n; }
 void Function::setStartLine(const retdec::common::Address& l)       { _startLine = l; }
 void Function::setEndLine(const retdec::common::Address& l)         { _endLine = l; }
+void Function::setIsDecompilerDefined()                     { _linkType = DECOMPILER_DEFINED; }
 void Function::setIsUserDefined()                           { _linkType = USER_DEFINED; }
 void Function::setIsStaticallyLinked() const                { _linkType = STATICALLY_LINKED; }
 void Function::setIsDynamicallyLinked() const               { _linkType = DYNAMICALLY_LINKED; }

--- a/src/llvmir2hll/config/configs/json_config.cpp
+++ b/src/llvmir2hll/config/configs/json_config.cpp
@@ -221,11 +221,16 @@ LineRange JSONConfig::getLineRangeForFunc(const std::string &func) const {
 	return LineRange(startLine.getValue(), endLine.getValue());
 }
 
-bool JSONConfig::isUserDefinedFunc(const std::string &func) const {
+bool JSONConfig::isDecompilerDefinedFunc(const std::string &func) const {
 	// We cannot use getConfigFunctionByNameOrEmptyFunction() because config
-	// functions are user-defined by default.
+	// functions are decompiler-defined by default.
 	const auto f = impl->getConfigFunctionByName(func);
-	return f ? f->isUserDefined() : false;
+	return f ? f->isDecompilerDefined() : false;
+}
+
+bool JSONConfig::isUserDefinedFunc(const std::string &func) const {
+	const auto &f = impl->getConfigFunctionByNameOrEmptyFunction(func);
+	return f.isUserDefined();
 }
 
 bool JSONConfig::isStaticallyLinkedFunc(const std::string &func) const {

--- a/src/llvmir2hll/hll/hll_writers/c_hll_writer.cpp
+++ b/src/llvmir2hll/hll/hll_writers/c_hll_writer.cpp
@@ -1258,17 +1258,19 @@ bool CHLLWriter::emitStandardFunctionPrototypes() {
 	//
 	//   - All functions with bodies.
 	//   - All functions marked as "user-defined".
+	//   - All functions marked as "decompiler-defined".
 	//
 	// Notes:
 	//
-	//   - We cannot consider just user-defined functions because there may be
-	//     no config file from which this information is taken (in such case, we
-	//     would emit no function prototypes at all).
+	//   - We cannot consider just user-defined and decompiler-defined functions
+	//     because there may be no config file from which this information is
+	//     taken (in such case, we would emit no function prototypes at all).
 	FuncSet funcsToEmit(
 		module->func_definition_begin(),
 		module->func_definition_end()
 	);
 	addToSet(module->getUserDefinedFuncs(), funcsToEmit);
+	addToSet(module->getDecompilerDefinedFuncs(), funcsToEmit);
 	return emitFunctionPrototypes(funcsToEmit);
 }
 

--- a/src/llvmir2hll/ir/module.cpp
+++ b/src/llvmir2hll/ir/module.cpp
@@ -375,6 +375,29 @@ bool Module::hasFuncDefinitions() const {
 }
 
 /**
+* @brief Are there any decompiler-defined functions in the module?
+*/
+bool Module::hasDecompilerDefinedFuncs() const {
+	for (auto &func : funcs) {
+		if (config->isDecompilerDefinedFunc(func->getInitialName())) {
+			return true;
+		}
+	}
+	return false;
+}
+
+/**
+* @brief Returns all decompiler-defined functions in the module.
+*/
+FuncSet Module::getDecompilerDefinedFuncs() const {
+	return getFuncsSatisfyingPredicate(
+		[this](auto func) {
+			return config->isDecompilerDefinedFunc(func->getInitialName());
+		}
+	);
+}
+
+/**
 * @brief Are there any user-defied functions in the module?
 */
 bool Module::hasUserDefinedFuncs() const {

--- a/src/serdes/function.cpp
+++ b/src/serdes/function.cpp
@@ -51,6 +51,7 @@ const std::string JSON_basicBlocks   = "basicBlocks";
 
 std::vector<std::string> fncTypes =
 {
+	"decompilerDefined",
 	"userDefined",
 	"staticallyLinked",
 	"dynamicallyLinked",

--- a/tests/llvmir2hll/config/config_mock.h
+++ b/tests/llvmir2hll/config/config_mock.h
@@ -30,6 +30,7 @@ public:
 	MOCK_CONST_METHOD1(getAddressRangeForFunc, AddressRange (const std::string &));
 	MOCK_CONST_METHOD1(getLineRangeForFunc, LineRange (const std::string &));
 	MOCK_CONST_METHOD1(isUserDefinedFunc, bool (const std::string &));
+	MOCK_CONST_METHOD1(isDecompilerDefinedFunc, bool (const std::string &));
 	MOCK_CONST_METHOD1(isStaticallyLinkedFunc, bool (const std::string &));
 	MOCK_CONST_METHOD1(isDynamicallyLinkedFunc, bool (const std::string &));
 	MOCK_CONST_METHOD1(isSyscallFunc, bool (const std::string &));

--- a/tests/llvmir2hll/config/configs/json_config_tests.cpp
+++ b/tests/llvmir2hll/config/configs/json_config_tests.cpp
@@ -425,6 +425,46 @@ IsUserDefinedFuncReturnsTrueWhenFuncIsUserDefined) {
 }
 
 //
+// isDecompilerDefinedFunc()
+//
+
+TEST_F(JSONConfigTests,
+IsDecompilerDefinedFuncReturnsFalseWhenThereIsNoInfoForFunc) {
+	auto config = JSONConfig::empty();
+
+	ASSERT_FALSE(config->isDecompilerDefinedFunc("my_func"));
+}
+
+TEST_F(JSONConfigTests,
+IsDecompilerDefinedFuncReturnsFalseWhenFuncIsDynamicallyLinked) {
+	auto config = JSONConfig::fromString(R"({
+		"functions": [
+			{
+				"name": "my_func",
+				"fncType": "dynamicallyLinked"
+			}
+		]
+	})");
+
+	ASSERT_FALSE(config->isDecompilerDefinedFunc("my_func"));
+}
+
+
+TEST_F(JSONConfigTests,
+IsDecompilerDefinedFuncReturnsTrueWhenFuncIsDecompilerDefined) {
+	auto config = JSONConfig::fromString(R"({
+		"functions": [
+			{
+				"name": "my_func",
+				"fncType": "decompilerDefined"
+			}
+		]
+	})");
+
+	ASSERT_TRUE(config->isDecompilerDefinedFunc("my_func"));
+}
+
+//
 // isStaticallyLinkedFunc()
 //
 

--- a/tests/llvmir2hll/hll/hll_writers/hll_writer_tests.cpp
+++ b/tests/llvmir2hll/hll/hll_writers/hll_writer_tests.cpp
@@ -37,6 +37,8 @@ void HLLWriterTests::SetUp() {
 		.WillByDefault(Return(NO_LINE_RANGE));
 	ON_CALL(*configMock, isUserDefinedFunc(_))
 		.WillByDefault(Return(false));
+	ON_CALL(*configMock, isDecompilerDefinedFunc(_))
+		.WillByDefault(Return(false));
 	ON_CALL(*configMock, isStaticallyLinkedFunc(_))
 		.WillByDefault(Return(false));
 	ON_CALL(*configMock, isDynamicallyLinkedFunc(_))

--- a/tests/llvmir2hll/ir/module_tests.cpp
+++ b/tests/llvmir2hll/ir/module_tests.cpp
@@ -285,6 +285,55 @@ HasUserDefinedFuncsReturnsTrueWhenThereIsDefinitionOfUserDefinedFunc) {
 }
 
 //
+// getDecompilerDefinedFuncs()
+//
+
+TEST_F(ModuleTests,
+GetDecompilerDefinedFuncsReturnsEmptySetWhenThereAreNoFuncs) {
+	ASSERT_EQ(FuncSet(), module->getDecompilerDefinedFuncs());
+}
+
+TEST_F(ModuleTests,
+GetDecompilerDefinedFuncsReturnsCorrectValueWhenThereAreDecompilerDefinedFunc) {
+	// Check that both declarations and definitions are checked.
+	auto myFunc1 = addFuncDecl("my_func1");
+	EXPECT_CALL(*configMock, isDecompilerDefinedFunc(myFunc1->getName()))
+		.WillOnce(Return(true));
+	auto myFunc2 = addFuncDef("my_func2");
+	EXPECT_CALL(*configMock, isDecompilerDefinedFunc(myFunc2->getName()))
+		.WillOnce(Return(true));
+
+	ASSERT_EQ(FuncSet({myFunc1, myFunc2}), module->getDecompilerDefinedFuncs());
+}
+
+//
+// hasDecompilerDefinedFuncs()
+//
+
+TEST_F(ModuleTests,
+HasDecompilerDefinedFuncsReturnsFalseWhenThereAreNoFuncs) {
+	ASSERT_FALSE(module->hasDecompilerDefinedFuncs());
+}
+
+TEST_F(ModuleTests,
+HasDecompilerDefinedFuncsReturnsTrueWhenThereIsDeclarationOfDecompilerDefinedFunc) {
+	auto myFunc = addFuncDecl("my_func");
+	EXPECT_CALL(*configMock, isDecompilerDefinedFunc(myFunc->getName()))
+		.WillOnce(Return(true));
+
+	ASSERT_TRUE(module->hasDecompilerDefinedFuncs());
+}
+
+TEST_F(ModuleTests,
+HasDecompilerDefinedFuncsReturnsTrueWhenThereIsDefinitionOfDecompilerDefinedFunc) {
+	auto myFunc = addFuncDef("my_func");
+	EXPECT_CALL(*configMock, isDecompilerDefinedFunc(myFunc->getName()))
+		.WillOnce(Return(true));
+
+	ASSERT_TRUE(module->hasDecompilerDefinedFuncs());
+}
+
+//
 // getUserDefinedFuncs()
 //
 


### PR DESCRIPTION
Hi in this PR I want to request and discuss a design change of function type in RetDec config.

Before this PR function type might have been one of the following:
  - USER_DEFINED
  - STATICALLY_LINKED
  - DYNAMICALLY_LINKED
  - SYSCALL
  - IDIOM

The default function type that was generated for every function was
USER_DEFINED. This in my opinion is not right as we have to distinguish functions that
were provided by user through some kind of front-end and functions that
were automatically detected by decompiler. This is why I propose new type
- DECOMPILER_DEFINED.

A reason to distinguish these two function types is for example in parameter
analysis. When user specifies that the return type is integer, the decompiler
should not continue to do heuristics to detect return type. If an user
wants a function to be of some type they should get the function with the type
on output. Also this brings more flexibility when it comes to creation of custom plugins
that provide data to RetDec (like r2plugin).

I traced every implementation/usage of previous default type (USER_DEFINED) and changed it accordingly. 