### PR TITLE
Improve the detection of AutoIT files compiled to binary.

### DIFF
--- a/support/yara_patterns/tools/pe/x64/compilers.yara
+++ b/support/yara_patterns/tools/pe/x64/compilers.yara
@@ -117,6 +117,25 @@ rule aut2exe_33143 {
 		$1 at 0x400
 }
 
+rule aut2exe_uv_01 {
+	meta:
+		tool = "C"
+		name = "Aut2Exe"
+		language = "AutoIt"
+		bytecode = true
+	strings:
+		$1 = ">AUTOIT SCRIPT<"
+		$2 = ">AUTOIT SCRIPT<" wide
+		$3 = ">AUTOIT UNICODE SCRIPT<" wide
+	condition:
+		pe.is_64bit() and
+		for 1 of them : (
+			@ > pe.sections[pe.section_index(".rdata")].raw_data_offset and
+			@ < pe.sections[pe.section_index(".rdata")].raw_data_offset +
+			pe.sections[pe.section_index(".rdata")].raw_data_size
+		)
+}
+
 rule autohotkey_uv_01 {
 	meta:
 		tool = "C"

--- a/support/yara_patterns/tools/pe/x86/compilers.yara
+++ b/support/yara_patterns/tools/pe/x86/compilers.yara
@@ -228,6 +228,25 @@ rule aut2exe_33143 {
 		$1 at pe.entry_point
 }
 
+rule aut2exe_uv_01 {
+	meta:
+		tool = "C"
+		name = "Aut2Exe"
+		language = "AutoIt"
+		bytecode = true
+	strings:
+		$1 = ">AUTOIT SCRIPT<"
+		$2 = ">AUTOIT SCRIPT<" wide
+		$3 = ">AUTOIT UNICODE SCRIPT<" wide
+	condition:
+		pe.is_32bit() and
+		for 1 of them : (
+			@ > pe.sections[pe.section_index(".rdata")].raw_data_offset and
+			@ < pe.sections[pe.section_index(".rdata")].raw_data_offset +
+			pe.sections[pe.section_index(".rdata")].raw_data_size
+		)
+}
+
 rule autohotkey_uv_01 {
 	meta:
 		tool = "C"


### PR DESCRIPTION
AutoIT files compiled to binary using Aut2Exe are a regular PE file that
has its script embedded. This commit adds additional checks to catch and
detect the previously undetected version of the compiler.

The tests have been added [here](avast/retdec-regression-tests/pull/55)