### PR TITLE
fileformat/format_detection: use file magic to detect COFF files.

### DIFF
--- a/src/fileformat/file_format/coff/coff_format.cpp
+++ b/src/fileformat/file_format/coff/coff_format.cpp
@@ -507,30 +507,14 @@ bool CoffFormat::getRelocationMask(unsigned relType, std::vector<std::uint8_t> &
 
 retdec::utils::Endianness CoffFormat::getEndianness() const
 {
-	switch(file->getMachine())
+	const llvm::object::coff_bigobj_file_header* bigHeader = nullptr;
+	if (!file->getCOFFBigObjHeader(bigHeader) && bigHeader)
 	{
-		case PELIB_IMAGE_FILE_MACHINE_I386:
-		case PELIB_IMAGE_FILE_MACHINE_I486:
-		case PELIB_IMAGE_FILE_MACHINE_PENTIUM:
-		case PELIB_IMAGE_FILE_MACHINE_AMD64:
-		case PELIB_IMAGE_FILE_MACHINE_R3000_LITTLE:
-		case PELIB_IMAGE_FILE_MACHINE_R4000:
-		case PELIB_IMAGE_FILE_MACHINE_R10000:
-		case PELIB_IMAGE_FILE_MACHINE_WCEMIPSV2:
-		case PELIB_IMAGE_FILE_MACHINE_MIPS16:
-		case PELIB_IMAGE_FILE_MACHINE_MIPSFPU:
-		case PELIB_IMAGE_FILE_MACHINE_MIPSFPU16:
-		case PELIB_IMAGE_FILE_MACHINE_ARM:
-		case PELIB_IMAGE_FILE_MACHINE_THUMB:
-		case PELIB_IMAGE_FILE_MACHINE_ARMNT:
-		case PELIB_IMAGE_FILE_MACHINE_ARM64:
-		case PELIB_IMAGE_FILE_MACHINE_POWERPC:
-		case PELIB_IMAGE_FILE_MACHINE_POWERPCFP:
-			return Endianness::LITTLE;
-		case PELIB_IMAGE_FILE_MACHINE_R3000_BIG:
-			return Endianness::BIG;
-		default:
-			return Endianness::UNKNOWN;
+		return Endianness::BIG;
+	}
+	else
+	{
+		return Endianness::LITTLE;
 	}
 }
 

--- a/src/fileformat/utils/format_detection.cpp
+++ b/src/fileformat/utils/format_detection.cpp
@@ -36,22 +36,55 @@ const std::map<std::pair<std::size_t, std::string>, Format> magicFormatMap =
 	// PE
 	{{0, "MZ"}, Format::PE},
 	{{0, "ZM"}, Format::PE},
-	// COFF
-	{{0, "\xc4""\x01"}, Format::COFF}, // ARM little
-	{{0, "\x4c""\x01"}, Format::COFF}, // x86 little
+
+	// COFF - only Little endian variants.
+	// See PELIB_IMAGE_FILE_MACHINE.
+	{{0, "\x4c""\x01"}, Format::COFF}, // PELIB_IMAGE_FILE_MACHINE_I386
+	{{0, "\x4d""\x01"}, Format::COFF}, // PELIB_IMAGE_FILE_MACHINE_I486
+	{{0, "\x4e""\x01"}, Format::COFF}, // PELIB_IMAGE_FILE_MACHINE_PENTIUM
+	{{0, "\x84""\x01"}, Format::COFF}, // PELIB_IMAGE_FILE_MACHINE_ALPHA
+	{{0, "\xa2""\x01"}, Format::COFF}, // PELIB_IMAGE_FILE_MACHINE_SH3
+	{{0, "\xa3""\x01"}, Format::COFF}, // PELIB_IMAGE_FILE_MACHINE_SH3DSP
+	{{0, "\xa4""\x01"}, Format::COFF}, // PELIB_IMAGE_FILE_MACHINE_SH3E
+	{{0, "\xa6""\x01"}, Format::COFF}, // PELIB_IMAGE_FILE_MACHINE_SH4
+	{{0, "\xa8""\x01"}, Format::COFF}, // PELIB_IMAGE_FILE_MACHINE_SH5
+
+	{{0, "\xc0""\x01"}, Format::COFF}, // PELIB_IMAGE_FILE_MACHINE_ARM
+	{{0, "\xc2""\x01"}, Format::COFF}, // PELIB_IMAGE_FILE_MACHINE_THUMB
+	{{0, "\xc4""\x01"}, Format::COFF}, // PELIB_IMAGE_FILE_MACHINE_ARMNT
+	{{0, "\xd3""\x01"}, Format::COFF}, // PELIB_IMAGE_FILE_MACHINE_AM33
+	{{0, "\xf0""\x01"}, Format::COFF}, // PELIB_IMAGE_FILE_MACHINE_POWERPC
+
+	{{0, std::string("\x00\x02", 2)}, Format::COFF}, // PELIB_IMAGE_FILE_MACHINE_POWERPCFP
+	{{0, "\xc4""\x01"}, Format::COFF}, // PELIB_IMAGE_FILE_MACHINE_IA64
+	{{0, "\x68""\x02"}, Format::COFF}, // PELIB_IMAGE_FILE_MACHINE_MOTOROLA68000
+	{{0, "\x90""\x02"}, Format::COFF}, // PELIB_IMAGE_FILE_MACHINE_PARISC
+	{{0, "\x84""\x02"}, Format::COFF}, // PELIB_IMAGE_FILE_MACHINE_ALPHA64
+
 	// https://opensource.apple.com/source/file/file-23/file/magic/Magdir/mips.auto.html
-	{{0, "\x01""\x60"}, Format::COFF}, // MIPSEB ECOFF executable
-	{{0, "\x60""\x01"}, Format::COFF}, // MIPSEB-LE ECOFF executable
-	{{0, "\x01""\x62"}, Format::COFF}, // MIPSEL-BE ECOFF executable
-	{{0, "\x62""\x01"}, Format::COFF}, // MIPSEL ECOFF executable
-	{{0, "\x01""\x63"}, Format::COFF}, // MIPSEB MIPS-II ECOFF executable
+	{{0, "\x60""\x01"}, Format::COFF}, // PELIB_IMAGE_FILE_MACHINE_R3000_BIG, MIPSEB-LE ECOFF executable
+	{{0, "\x62""\x01"}, Format::COFF}, // PELIB_IMAGE_FILE_MACHINE_R3000_LITTLE, MIPSEL ECOFF executable
 	{{0, "\x63""\x01"}, Format::COFF}, // MIPSEB-LE MIPS-II ECOFF executable
-	{{0, "\x01""\x66"}, Format::COFF}, // MIPSEL-BE MIPS-II ECOFF executable
-	{{0, "\x66""\x01"}, Format::COFF}, // MIPSEL MIPS-II ECOFF executable
-	{{0, "\x01""\x40"}, Format::COFF}, // MIPSEB MIPS-III ECOFF executable
+	{{0, "\x66""\x01"}, Format::COFF}, // PELIB_IMAGE_FILE_MACHINE_R4000, MIPSEL MIPS-II ECOFF executable
 	{{0, "\x40""\x01"}, Format::COFF}, // MIPSEB-LE MIPS-III ECOFF executable
-	{{0, "\x01""\x42"}, Format::COFF}, // MIPSEL-BE MIPS-III ECOFF executable
 	{{0, "\x42""\x01"}, Format::COFF}, // MIPSEL MIPS-III ECOFF executable
+	{{0, "\x66""\x02"}, Format::COFF}, // PELIB_IMAGE_FILE_MACHINE_MIPS16
+	{{0, "\x68""\x01"}, Format::COFF}, // PELIB_IMAGE_FILE_MACHINE_R10000
+	{{0, "\x69""\x01"}, Format::COFF}, // PELIB_IMAGE_FILE_MACHINE_WCEMIPSV2
+	{{0, "\x66""\x03"}, Format::COFF}, // PELIB_IMAGE_FILE_MACHINE_MIPSFPU
+	{{0, "\x66""\x04"}, Format::COFF}, // PELIB_IMAGE_FILE_MACHINE_MIPSFPU16
+	{{0, "\x20""\x05"}, Format::COFF}, // PELIB_IMAGE_FILE_MACHINE_TRICORE
+	{{0, "\xbc""\x0e"}, Format::COFF}, // PELIB_IMAGE_FILE_MACHINE_EBC
+	{{0, "\x64""\x86"}, Format::COFF}, // PELIB_IMAGE_FILE_MACHINE_AMD64
+	{{0, "\x41""\x90"}, Format::COFF}, // PELIB_IMAGE_FILE_MACHINE_M32R
+	{{0, "\x64""\xaa"}, Format::COFF}, // PELIB_IMAGE_FILE_MACHINE_ARM64
+	{{0, "\xee""\xc0"}, Format::COFF}, // PELIB_IMAGE_FILE_MACHINE_MSIL
+	// COFF - big endian magic
+	// Big endian COFFs should start with 0000ffff but this long magic should
+	// be enough.
+	// See LLVM's COFF.h BigObjMagic
+	{{0xc, "\xc7\xa1\xba\xd1\xee\xba\xa9\x4b\xaf\x20\xfa\xf6\x6a\xa4\xdc\xb8"}, Format::COFF},
+
 	// ELF
 	{{0, "\x7F""ELF"}, Format::ELF},
 	// Intel-Hex


### PR DESCRIPTION
Do not parse COFF files at format detection stage - this could be slow if the file is big.