### PR TITLE
* Fixed high memory usage on samples with screwed up delayed imports

### DIFF
--- a/include/retdec/pelib/DelayImportDirectory.h
+++ b/include/retdec/pelib/DelayImportDirectory.h
@@ -103,7 +103,7 @@ namespace PeLib
 				init();
 
 				// Keep loading until we encounter an entry filles with zeros
-				for(std::size_t i = 0;; i += sizeof(PELIB_IMAGE_DELAY_LOAD_DESCRIPTOR))
+				for(std::uint32_t i = 0;; i += sizeof(PELIB_IMAGE_DELAY_LOAD_DESCRIPTOR))
 				{
 					PELIB_IMAGE_DELAY_IMPORT_DIRECTORY_RECORD rec;
 
@@ -111,6 +111,10 @@ namespace PeLib
 					if((rva + i) >= sizeOfImage)
 						break;
 					if(!imageLoader.readImage(&rec.delayedImport, rva + i, sizeof(PELIB_IMAGE_DELAY_LOAD_DESCRIPTOR)))
+						break;
+
+					// Valid delayed import entry starts either with 0 or 0x01
+					if(rec.delayedImport.Attributes & 0xFFFF0000)
 						break;
 
 					// Check for the termination entry

--- a/src/pelib/ImageLoader.cpp
+++ b/src/pelib/ImageLoader.cpp
@@ -210,9 +210,9 @@ uint32_t PeLib::ImageLoader::stringLength(
 					const uint8_t * dataPtr;
 					uint32_t rvaEndPage = (pageIndex + 1) * PELIB_PAGE_SIZE;
 
-					// If zero page, means we found an RVA with zero
+					// If zero page, means this is a zeroed page. This is the end of the string.
 					if(page.buffer.empty())
-						return rva;
+						break;
 					dataBegin = dataPtr = page.buffer.data() + (rva & (PELIB_PAGE_SIZE - 1));
 
 					// Perhaps the last page loaded?


### PR DESCRIPTION
* ImageLoader::stringLength() now stops properly on zero pages