### PR TITLE
fileformat: Include pkcs7.h instead of doing forward declarations.

### DIFF
--- a/include/retdec/fileformat/file_format/pe/pe_format.h
+++ b/include/retdec/fileformat/file_format/pe/pe_format.h
@@ -17,10 +17,7 @@
 #include "retdec/fileformat/types/dotnet_types/dotnet_class.h"
 #include "retdec/fileformat/types/visual_basic/visual_basic_info.h"
 #include "retdec/pelib/PeFile.h"
-
-// Forward declare OpenSSL structures used in this header.
-typedef struct pkcs7_st PKCS7;
-typedef struct evp_md_st EVP_MD;
+#include "openssl/pkcs7.h"
 
 namespace retdec {
 namespace fileformat {


### PR DESCRIPTION
Fixes:
In file included from ../retdec/src/fileformat/file_format/pe/pe_format.cpp:24:
../retdec/include/retdec/fileformat/file_format/pe/pe_format.h:23:26: error: conflicting declaration ‘typedef struct evp_md_st EVP_MD’
   23 | typedef struct evp_md_st EVP_MD;
      |                          ^~~~~~
In file included from /usr/include/openssl/crypto.h:129,
                 from /usr/include/openssl/bio.h:69,
                 from /usr/include/openssl/asn1.h:67,
                 from ../retdec/src/fileformat/file_format/pe/pe_format.cpp:15:
/usr/include/openssl/ossl_typ.h:113:26: note: previous declaration as ‘typedef struct env_md_st EVP_MD’
  113 | typedef struct env_md_st EVP_MD;
      |                          ^~~~~~