### PR TITLE
Fix crash on samples having corrupted PE header (#821)

### DIFF
--- a/src/cpdetect/heuristics/pe_heuristics.cpp
+++ b/src/cpdetect/heuristics/pe_heuristics.cpp
@@ -937,7 +937,7 @@ void PeHeuristics::getUpxHeuristics()
 	// format: x.xx'\0'UPX!
 	const std::size_t minPos = 5, verLen = 4;
 	pos = content.find("UPX!");
-	if (pos >= minPos && pos < 0x500 && pos < sections[0]->getOffset())
+	if (pos >= minPos && pos < 0x500 && !sections.empty() && pos < sections[0]->getOffset())
 	{
 		std::string version;
 		std::size_t num;


### PR DESCRIPTION
If a sample has corrupted PE header and as a result does not have any
sections, heuristic search for UPX packer will fail as it tries to
access the first section. To remedy this, we need to ensure the sections
exist before we access them.

Issue #821 

Test added [here](https://github.com/avast/retdec-regression-tests/pull/68)