### PR TITLE
Fix invalid memory read in PeLib::CoffSymbolTable::read() (#840)

### DIFF
--- a/src/pelib/CoffSymbolTable.cpp
+++ b/src/pelib/CoffSymbolTable.cpp
@@ -94,11 +94,9 @@ namespace PeLib
 		// Read size of string table
 		if (ulFileSize >= stringTableOffset + 4)
 		{
-			stringTable.push_back(fileData[stringTableOffset]);
-			stringTable.push_back(fileData[stringTableOffset + 1]);
-			stringTable.push_back(fileData[stringTableOffset + 2]);
-			stringTable.push_back(fileData[stringTableOffset + 3]);
-			memcpy(&stringTableSize, stringTable.data(), sizeof(uint32_t));
+			stringTable.resize(sizeof(std::uint32_t));
+			memcpy(&stringTableSize, fileData.data() + stringTableOffset, sizeof(uint32_t));
+			*reinterpret_cast<std::uint32_t *>(stringTable.data()) = stringTableSize;
 			uiOffset = stringTableOffset + sizeof(uint32_t);
 		}
 

--- a/src/pelib/CoffSymbolTable.cpp
+++ b/src/pelib/CoffSymbolTable.cpp
@@ -94,7 +94,11 @@ namespace PeLib
 		// Read size of string table
 		if (ulFileSize >= stringTableOffset + 4)
 		{
-			memcpy(&stringTableSize, fileData.data() + stringTableOffset, sizeof(uint32_t));
+			stringTable.push_back(fileData[stringTableOffset]);
+			stringTable.push_back(fileData[stringTableOffset + 1]);
+			stringTable.push_back(fileData[stringTableOffset + 2]);
+			stringTable.push_back(fileData[stringTableOffset + 3]);
+			memcpy(&stringTableSize, stringTable.data(), sizeof(uint32_t));
 			uiOffset = stringTableOffset + sizeof(uint32_t);
 		}
 


### PR DESCRIPTION
Fixes #840.