### PR TITLE
utils: fix #842, always link stdc++fs if linux & gcc.

### DIFF
--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -30,14 +30,23 @@ target_include_directories(utils
 
 # We may need to link filesystem library manually.
 find_library(STD_CPP_FS stdc++fs)
+# Library found -> link against it.
 if (STD_CPP_FS)
-	message(STATUS "-- Linking with ${STD_CPP_FS} library")
+	message(STATUS "-- Library stdc++fs found -> Linking with ${STD_CPP_FS}")
 	target_link_libraries(utils
 		PRIVATE
 			stdc++fs
 	)
+# Library not found & (Linux, BSD, Solaris, Minix) & GCC
+elseif(UNIX AND (NOT APPLE) AND CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+	message(STATUS "-- Library stdc++fs NOT found & Linux+GCC -> Linking with stdc++fs")
+	target_link_libraries(utils
+		PRIVATE
+			stdc++fs
+	)
+# Library not found -> hope compiler does not need it.
 else()
-	message(STATUS "-- Library stdc++fs NOT FOUND -> linking utils without stdc++fs library")
+	message(STATUS "-- Library stdc++fs NOT found -> linking utils without stdc++fs library")
 endif()
 
 # Disable the min() and max() macros to prevent errors when using e.g.


### PR DESCRIPTION
Try to fix #842 by always linking against stdc++fs on Linux&GCC combo.

Notes:
* This might cause problems (later/now) on some system - if there is no stdc++fs known to GCC, linking against it will probably end up with error.
* We could use [`CMAKE_CXX_COMPILER_VERSION`](https://cmake.org/cmake/help/latest/variable/CMAKE_LANG_COMPILER_VERSION.html) to check for GCC 7/8, but I didn't want to complicate it.

@xkubov Please take a look and merge if ok.