### PR TITLE
Fix infinite loops in copy propagation optimizer

### DIFF
--- a/src/llvmir2hll/optimizer/optimizers/copy_propagation_optimizer.cpp
+++ b/src/llvmir2hll/optimizer/optimizers/copy_propagation_optimizer.cpp
@@ -841,14 +841,14 @@ void CopyPropagationOptimizer::handleCaseInductionVariable(
 
 	// Other value is undefined before the other definition.
 	bool ok = false;
-	auto prev = commonOtherDef->getUniquePredecessor();
-	while (prev) {
+	std::set<ShPtr<Statement>> visited;
+	for (auto prev = commonOtherDef->getUniquePredecessor(); prev && visited.insert(prev).second;
+		prev = prev->getUniquePredecessor()) {
 		auto vds = cast<VarDefStmt>(prev);
 		if (vds && vds->getVar() == otherValue && vds->getInitializer() == nullptr) {
 			ok = true;
 			break;
 		}
-		prev = prev->getUniquePredecessor();
 	}
 	// Other value may be in another BB.
 	// In such a case, check for very specific and restrictive pattern.
@@ -1043,8 +1043,9 @@ void CopyPropagationOptimizer::handleCaseInductionVariable2(
 	// y is undefined before xZero.
 	// y = undef
 	bool ok = false;
-	auto prev = xZero->getUniquePredecessor();
-	while (prev) {
+	std::set<ShPtr<Statement>> visited;
+	for (auto prev = xZero->getUniquePredecessor(); prev && visited.insert(prev).second;
+		prev = prev->getUniquePredecessor()) {
 		auto vds = cast<VarDefStmt>(prev);
 		if (vds && vds->getVar() == y) {
 			ok = (vds->getInitializer() == nullptr);
@@ -1054,7 +1055,6 @@ void CopyPropagationOptimizer::handleCaseInductionVariable2(
 		if (as && as->getLhs() == y) {
 			break;
 		}
-		prev = prev->getUniquePredecessor();
 	}
 	if (!ok) {
 		LOG << "\t" << "end 10" << std::endl;


### PR DESCRIPTION
I came across a couple of infinite loops in copy_propagation_optimizer.cpp using the attach file.

[sslvpnd.zip](https://github.com/avast/retdec/files/5465739/sslvpnd.zip)

The sslvpnd binary should have a `sha256sum` of 856b68307d53d0f20f5c4a91aefc3146382e4e4210c758655d53135669642557 or you can find the binary embedded in this [firmware](https://www.cisco.com/c/en/us/support/routers/rv340-dual-gigabit-wan-vpn-router/model.html#~tab-downloads).

The infinite loop(s) can be reproduced by fetching retdec master from Github, compiling, and executing retdec-decompiler:

```
albinolobster@ubuntu:~/retdec/build$ retdec-decompiler ~/sslvpnd
```

After a couple of minutes, retdec drops into an infinite. The issue appears to be similar to [55d46b5f3a4a5ec038ab33331926a195c7f33250](https://github.com/avast/retdec/commit/55d46b5f3a4a5ec038ab33331926a195c7f33250), in that copy_progragation_optimizer is walking backwards through statements that loop. I followed a similar solution as introduced in the previous commit, basically exiting the loop if we see the same statement twice. With this change, sslvpnd is successfully processed after approximately 5 minutes.

I looked at the style guide and I'm not 100% my for loop line break is okay or not. Happy to fix if needed.
