### PR TITLE
Fix missing comma in usualPackerSections initializer

### DIFF
--- a/src/fileformat/file_format/pe/pe_format.cpp
+++ b/src/fileformat/file_format/pe/pe_format.cpp
@@ -365,7 +365,7 @@ const std::unordered_set<std::string> usualPackerSections
 	".vmp1",
 	".vmp2",
 	".winapi",
-	".y0da"
+	".y0da",
 	".yP",
 	"ASPack",
 	"BitArts",


### PR DESCRIPTION
While I was working on Signatures, I've noticed that usualPackerSections set is missing a comma in it's initializer, I think this is not intended?