### PR TITLE
Fixed possible access to unallocated memory in MPRESS unpacker

### DIFF
--- a/src/unpackertool/plugins/mpress/mpress.cpp
+++ b/src/unpackertool/plugins/mpress/mpress.cpp
@@ -234,7 +234,7 @@ std::uint32_t MpressPlugin::getFixStub()
 void MpressPlugin::fixJumpsAndCalls(DynamicBuffer& buffer)
 {
 	std::uint32_t pos = 0;
-	std::uint32_t maxAddr = buffer.getRealDataSize() - 0x1000;
+	std::uint32_t maxAddr = std::max(0, static_cast<std::int32_t>(buffer.getRealDataSize()) - 0x1000);
 	while (pos < maxAddr)
 	{
 		std::uint32_t moveOffset = pos;


### PR DESCRIPTION
If the size of data is less than 0x1000 then we can possibly underflow
unsigned int and access unallocated data.