### PR TITLE
unpacker/mpress: Properly copy non-packer related sections to the unpacked file

### DIFF
--- a/src/unpackertool/plugins/mpress/mpress.h
+++ b/src/unpackertool/plugins/mpress/mpress.h
@@ -86,7 +86,7 @@ private:
 	MpressUnpackerStub detectUnpackerStubVersion();
 	MpressFixStub detectFixStubVersion(retdec::utils::DynamicBuffer& unpackedContent);
 	void saveFile(const std::string& fileName, retdec::utils::DynamicBuffer& content);
-	void copySectionFromOriginalFile(std::uint32_t origSectIndex, const std::string& newFileName, std::uint32_t newSectIndex);
+	void copySectionFromOriginalFile(std::uint32_t origSectIndex, std::ostream& outputFile, std::uint32_t newSectIndex);
 
 	std::unique_ptr<retdec::loader::Image> _file;
 	PeLib::PeFileT * _peFile;

--- a/src/unpackertool/plugins/upx/pe/pe_upx_stub.cpp
+++ b/src/unpackertool/plugins/upx/pe/pe_upx_stub.cpp
@@ -1238,7 +1238,7 @@ template <int bits> void PeUpxStub<bits>::saveFile(const std::string& outputFile
 	if (!_coffSymbolTable.empty())
 		retdec::utils::writeFile(outputFileHandle, _coffSymbolTable, imageLoader.getPointerToSymbolTable());
 	outputFileHandle.close();
-	
+
 	// Write resources at the end, because they would be rewritten by unpackedData which have them zeroed
 	if((Rva = imageLoader.getDataDirRva(PeLib::PELIB_IMAGE_DIRECTORY_ENTRY_RESOURCE)) != 0)
 		_newPeFile->resDir().write(outputFile, imageLoader.getFileOffsetFromRva(Rva), Rva);


### PR DESCRIPTION
After the commit 60ea783b558cce9b1f1a419df9c75be15588f3d2, we've had MPRESS unpacker bugged. Specifically the part which copied sections from packed PE into unpacked PE, which were not modified by packing process at all. This resulted in files unpacked by our `retdec-unpacker` to miss things like exports, resources and other things which are usually placed in their own sections (apart from imports which were properly reconstructed and unpacked code).