### PR TITLE
Do not fail completely when retdec-archive-decompiler is not available

### DIFF
--- a/scripts/retdec-fileinfo.py
+++ b/scripts/retdec-fileinfo.py
@@ -15,10 +15,12 @@ import sys
 utils = importlib.import_module('retdec-utils')
 utils.check_python_version()
 utils.ensure_script_is_being_run_from_installed_retdec()
-retdec_archive_decompiler = importlib.import_module('retdec-archive-decompiler')
 
-ArchiveDecompiler = retdec_archive_decompiler.ArchiveDecompiler
-
+try:
+    retdec_archive_decompiler = importlib.import_module('retdec-archive-decompiler')
+    ArchiveDecompiler = retdec_archive_decompiler.ArchiveDecompiler
+except ImportError:
+    ArchiveDecompiler = None
 
 sys.stdout = utils.Unbuffered(sys.stdout)
 
@@ -78,6 +80,7 @@ def main():
         if args.json:
             archive_decompiler_args.append('--json')
 
+        assert ArchiveDecompiler is not None, "You need to install RetDec with Decompiler in order to analyze archives"
         decompiler = ArchiveDecompiler(archive_decompiler_args)
         sys.exit(decompiler.decompile_archive())
 


### PR DESCRIPTION
If only `retdec-fileinfo` and `retdec-unpacker` are built and installed, then `retdec-archive-decompiler` is not installed. However in order to import `retdec-fileinfo.py`, it needs `retdec-archive-decompiler.py`. We'd like to have retdec fileinfo config handled better (through some JSONs) but this should at least solve it temporarily until better solution is made.