### PR TITLE
Calculate Rich header hash

### DIFF
--- a/include/retdec/fileformat/types/rich_header/rich_header.h
+++ b/include/retdec/fileformat/types/rich_header/rich_header.h
@@ -31,6 +31,10 @@ class RichHeader
 		bool isValidStructure = false;   ///< @c true if header has valid structure
 		bool isSuspicious = false;       ///< @c true if content of header is suspicious
 		std::vector<std::uint8_t> bytes; ///< decrypted content of rich header
+		/// hashes of decrypted rich header
+		std::string sha256;
+		std::string md5;
+		std::string crc32;
 	public:
 		/// @name Getters
 		/// @{
@@ -43,6 +47,9 @@ class RichHeader
 		const LinkerInfo* getLastRecord() const;
 		bool getValidStructure() const;
 		bool getSuspicious() const;
+		std::string getSha256() const;
+		std::string getCrc32() const;
+		std::string getMd5() const;
 		const std::vector<std::uint8_t>& getBytes() const;
 		/// @}
 
@@ -54,6 +61,9 @@ class RichHeader
 		void setValidStructure(bool richValidStructure);
 		void setSuspicious(bool richSuspicious);
 		void setBytes(const std::vector<std::uint8_t>& richHeaderBytes);
+		void setSha256(const std::string& sha256);
+		void setCrc32(const std::string& crc32);
+		void setMd5(const std::string& md5);
 		/// @}
 
 		/// @name Iterators

--- a/src/fileformat/file_format/pe/pe_format.cpp
+++ b/src/fileformat/file_format/pe/pe_format.cpp
@@ -1113,7 +1113,17 @@ void PeFormat::loadRichHeader()
 
 	richHeader->setKey(header.getKey());
 	richHeader->setSignature(signature);
-	richHeader->setBytes(header.getDecryptedHeaderBytes());
+
+	auto decrypted_bytes = header.getDecryptedHeaderBytes();
+	richHeader->setBytes(decrypted_bytes);
+
+	auto crc32 = retdec::fileformat::getCrc32(decrypted_bytes.data(), decrypted_bytes.size());
+	auto md5 = retdec::fileformat::getMd5(decrypted_bytes.data(), decrypted_bytes.size());
+	auto sha256 = retdec::fileformat::getSha256(decrypted_bytes.data(), decrypted_bytes.size());
+
+	richHeader->setCrc32(crc32);
+	richHeader->setMd5(md5);
+	richHeader->setSha256(sha256);
 }
 
 /**

--- a/src/fileformat/types/rich_header/rich_header.cpp
+++ b/src/fileformat/types/rich_header/rich_header.cpp
@@ -109,6 +109,19 @@ bool RichHeader::getSuspicious() const
 	return isSuspicious;
 }
 
+std::string RichHeader::getSha256() const
+{
+	return sha256;
+}
+std::string RichHeader::getCrc32() const
+{
+	return crc32;
+}
+std::string RichHeader::getMd5() const
+{
+	return md5;
+}
+
 /**
  * Returns the decrypted bytes of the rich header.
  * @return Decrypted bytes of rich header.
@@ -165,6 +178,19 @@ void RichHeader::setValidStructure(bool richValidStructure)
 void RichHeader::setSuspicious(bool richSuspicious)
 {
 	isSuspicious = richSuspicious;
+}
+
+void RichHeader::setSha256(const std::string& sha256)
+{
+	this->sha256 = sha256;
+}
+void RichHeader::setCrc32(const std::string& crc32)
+{
+	this->crc32 = crc32;
+}
+void RichHeader::setMd5(const std::string& md5)
+{
+	this->md5 = md5;
 }
 
 /**

--- a/src/fileinfo/file_information/file_information.cpp
+++ b/src/fileinfo/file_information/file_information.cpp
@@ -790,6 +790,19 @@ bool FileInformation::hasRichHeaderRecords() const
 	return richHeader.hasRecords();
 }
 
+std::string FileInformation::getRichHeaderSha256() const
+{
+	return richHeader.getSha256();
+}
+std::string FileInformation::getRichHeaderCrc32() const
+{
+	return richHeader.getCrc32();
+}
+std::string FileInformation::getRichHeaderMd5() const
+{
+	return richHeader.getMd5();
+}
+
 /**
  * Check whether visual basic informations are used.
  * @return @c true if it is used, otherwise @c false/

--- a/src/fileinfo/file_information/file_information.h
+++ b/src/fileinfo/file_information/file_information.h
@@ -159,6 +159,9 @@ class FileInformation
 		std::string getRichHeaderRecordProductNameStr(std::size_t position) const;
 		std::string getRichHeaderRecordVisualStudioNameStr(std::size_t position) const;
 		std::string getRichHeaderRawBytesStr() const;
+		std::string getRichHeaderSha256() const;
+		std::string getRichHeaderCrc32() const;
+		std::string getRichHeaderMd5() const;
 		bool hasRichHeaderRecords() const;
 		/// @}
 

--- a/src/fileinfo/file_information/file_information_types/rich_header.cpp
+++ b/src/fileinfo/file_information/file_information_types/rich_header.cpp
@@ -114,6 +114,19 @@ std::vector<std::uint8_t> RichHeader::getRawBytes() const
 	return header ? header->getBytes() : std::vector<std::uint8_t>{};
 }
 
+std::string RichHeader::getSha256() const
+{
+	return header ? header->getSha256() : "";
+}
+std::string RichHeader::getCrc32() const
+{
+	return header ? header->getCrc32() : "";
+}
+std::string RichHeader::getMd5() const
+{
+	return header ? header->getMd5() : "";
+}
+
 /**
  * Set rich header data
  * @param richHeader Instance of class with original information about rich header
@@ -131,6 +144,8 @@ bool RichHeader::hasRecords() const
 {
 	return header ? header->hasRecords() : false;
 }
+
+
 
 } // namespace fileinfo
 } // namespace retdec

--- a/src/fileinfo/file_information/file_information_types/rich_header.h
+++ b/src/fileinfo/file_information/file_information_types/rich_header.h
@@ -31,6 +31,9 @@ class RichHeader
 		std::string getRecordNumberOfUsesStr(std::size_t position) const;
 		std::string getRecordProductNameStr(std::size_t position) const;
 		std::string getRecordVisualStudioNameStr(std::size_t position) const;
+		std::string getSha256() const;
+		std::string getCrc32() const;
+		std::string getMd5() const;
 		std::vector<std::uint8_t> getRawBytes() const;
 		/// @}
 

--- a/src/fileinfo/file_presentation/json_presentation.cpp
+++ b/src/fileinfo/file_presentation/json_presentation.cpp
@@ -291,6 +291,15 @@ void JsonPresentation::presentRichHeader(Writer& writer) const
 	serializeString(writer, "offset", offset);
 	serializeString(writer, "key", key);
 	serializeString(writer, "signature", sig);
+
+	auto crc32 = fileinfo.getRichHeaderCrc32();
+	auto md5 = fileinfo.getRichHeaderMd5();
+	auto sha256 = fileinfo.getRichHeaderSha256();
+	
+	serializeString(writer, "crc32", crc32);
+	serializeString(writer, "md5", md5);
+	serializeString(writer, "sha256", sha256);
+
 	writer.EndObject();
 }
 

--- a/src/fileinfo/file_presentation/plain_presentation.cpp
+++ b/src/fileinfo/file_presentation/plain_presentation.cpp
@@ -445,6 +445,19 @@ void PlainPresentation::presentRichHeader() const
 			Log::info() << (i ? std::string(signDesc.length(), ' ') : signDesc) << sig.substr(i, signLineLen) << "\n";
 		}
 	}
+	auto crc32 = fileinfo.getRichHeaderCrc32();
+	auto md5 = fileinfo.getRichHeaderMd5();
+	auto sha256 = fileinfo.getRichHeaderSha256();
+
+	if (!crc32.empty()) {
+		Log::info() << "Rich header CRC32        : " << crc32 << "\n";
+	}
+	if (!md5.empty()) {
+		Log::info() << "Rich header MD5          : " << md5 << "\n";
+	}
+	if (!sha256.empty()) {
+		Log::info() << "Rich header SHA256       : " << sha256 << "\n";
+	}
 }
 
 /**


### PR DESCRIPTION
I've added a calculation of decrypted (XORed) rich header hashes (crc32, md5, sha256) as mentioned in issue #621 . Not sure if all of them are wanted, probably MD5 only would be ok as used by VirusTotal: https://www.virustotal.com/gui/file/0ee196bb23f0eafe4f61d30bf6c676fd7365cb12ae66a6bde278851e91901ac1/details