### PR TITLE
Fix the Rich header analysis algorithm

### DIFF
--- a/include/retdec/pelib/RichHeader.h
+++ b/include/retdec/pelib/RichHeader.h
@@ -24,7 +24,7 @@ namespace PeLib
 			bool headerIsValid;
 			bool validStructure;
 			std::uint32_t key;
-			std::uint64_t offset;
+			std::uint64_t offset = 0;
 			std::size_t noOfIters;
 			std::vector<std::uint32_t> decryptedHeader;
 			std::vector<PELIB_IMAGE_RICH_HEADER_RECORD> records;

--- a/include/retdec/pelib/RichHeader.h
+++ b/include/retdec/pelib/RichHeader.h
@@ -24,6 +24,7 @@ namespace PeLib
 			bool headerIsValid;
 			bool validStructure;
 			std::uint32_t key;
+			std::uint64_t offset;
 			std::size_t noOfIters;
 			std::vector<std::uint32_t> decryptedHeader;
 			std::vector<PELIB_IMAGE_RICH_HEADER_RECORD> records;
@@ -45,6 +46,7 @@ namespace PeLib
 			bool isHeaderValid() const;
 			bool isStructureValid() const;
 			std::size_t getNumberOfIterations() const;
+			std::uint64_t getOffset() const;
 			std::uint32_t getKey() const;
 			const std::uint32_t* getDecryptedHeaderItem(std::size_t index) const;
 			std::string getDecryptedHeaderItemSignature(std::size_t index) const;

--- a/src/fileformat/file_format/pe/pe_format.cpp
+++ b/src/fileformat/file_format/pe/pe_format.cpp
@@ -740,7 +740,6 @@ bool PeFormat::getResourceNodes(std::vector<const PeLib::ResourceChild*> &nodes,
  */
 void PeFormat::loadRichHeader()
 {
-	// Sanity checks
 	if(getPeHeaderOffset() <= getMzHeaderSize())
 	{
 		return;

--- a/src/fileformat/file_format/pe/pe_format.cpp
+++ b/src/fileformat/file_format/pe/pe_format.cpp
@@ -740,6 +740,7 @@ bool PeFormat::getResourceNodes(std::vector<const PeLib::ResourceChild*> &nodes,
  */
 void PeFormat::loadRichHeader()
 {
+	// Sanity checks
 	if(getPeHeaderOffset() <= getMzHeaderSize())
 	{
 		return;
@@ -790,7 +791,6 @@ void PeFormat::loadRichHeader()
 	std::string signature;
 	richHeader = new RichHeader();
 	richHeader->setOffset(offset);
-	richHeader->setSuspicious(header.getNumberOfIterations() > 1);
 	richHeader->setValidStructure(true);
 	if(!header.isHeaderValid())
 	{
@@ -811,9 +811,16 @@ void PeFormat::loadRichHeader()
 
 		file->readRichHeader(maxOffset, getPeHeaderOffset() - maxOffset, true);
 		richHeader->setOffset(maxOffset);
-		richHeader->setSuspicious(header.getNumberOfIterations() > 1);
-		signature = header.getDecryptedHeaderItemsSignature({0, 1, 2, 3});
+		signature = header.getDecryptedHeaderItemsSignature({ 0, 1, 2, 3 });
 	}
+
+	richHeader->setSuspicious(header.getNumberOfIterations() > 1);
+
+	unsigned long long base_offset;
+	richHeader->getOffset(base_offset);
+	// in case the rich header does have junk data
+	// injected before and doesn't start exactly at offset
+	richHeader->setOffset(base_offset + header.getOffset());
 
 	for(const auto &item : header)
 	{

--- a/src/pelib/RichHeader.cpp
+++ b/src/pelib/RichHeader.cpp
@@ -797,7 +797,7 @@ namespace
 
 	/**
 	 * @brief Checks if the decrypted header looks valid, if it does
-	 * 	      then it analyses the header contents and saves it
+	 *        then it analyses the header contents and saves it
 	 *        into this->records
 	 * 
 	 * @param ignoreInvalidKey 
@@ -808,7 +808,8 @@ namespace
 	{
 		bool hValid = true;
 		size_t decSize = decryptedHeader.size();
-		if (decSize < 4) {
+		if (decSize < 4)
+		{
 			return false;
 		}
 		// Check if the start is "DanS" with 3 NULL
@@ -816,12 +817,14 @@ namespace
 		else if (decryptedHeader[0] != 0x536e6144 ||
 				decryptedHeader[1] != 0 ||
 				decryptedHeader[2] != 0 ||
-				decryptedHeader[3] != 0) {
-
-			if (ignoreInvalidKey) {
+				decryptedHeader[3] != 0)
+		{
+			if (ignoreInvalidKey)
+			{
 				hValid = false;
 			}
-			else {
+			else
+			{
 				return false;
 			}
 		}
@@ -879,12 +882,13 @@ namespace
 
 			// Start analyzing from the end - "Rich" marker
 			// and move upwards to decrypted "DanS" marker
-			for (auto i = richSignature - 1; i >= rich.begin(); --i) {
+			for (auto i = richSignature - 1; i >= rich.begin(); --i)
+			{
 				std::uint32_t decrypted_dword = *i ^ key;
 				decryptedHeader.push_back(decrypted_dword);
-
 				// "DanS" - 0x536e6144 signals the start (end) of the rich header
-				if (decrypted_dword == 0x536e6144) {
+				if (decrypted_dword == 0x536e6144)
+				{
 					// Set the offset to "DanS"
 					this->offset = (i - rich.begin()) * 4;
 					// Because we are analysing bottom up, reverse the vector
@@ -895,7 +899,8 @@ namespace
 			setValidStructure();
 		} while (!analyze());
 
-		if (ignoreInvalidKey && noOfIters) {
+		if (ignoreInvalidKey && noOfIters)
+		{
 			analyze(true);
 		}
 	}

--- a/src/pelib/RichHeader.cpp
+++ b/src/pelib/RichHeader.cpp
@@ -885,6 +885,8 @@ namespace
 
 				// "DanS" - 0x536e6144 signals the start (end) of the rich header
 				if (decrypted_dword == 0x536e6144) {
+					// Set the offset to "DanS"
+					this->offset = (i - rich.begin()) * 4;
 					// Because we are analysing bottom up, reverse the vector
 					std::reverse(decryptedHeader.begin(), decryptedHeader.end());
 					break;
@@ -935,6 +937,11 @@ namespace
 	bool RichHeader::isStructureValid() const
 	{
 		return validStructure;
+	}
+
+	std::uint64_t RichHeader::getOffset() const
+	{
+		return offset;
 	}
 
 	std::size_t RichHeader::getNumberOfIterations() const


### PR DESCRIPTION
This PR aims to fix #960 and to fix #965
The Rich header end is marked by the "Rich" marker somewhere between DOS header/stub and PE header. After the "Rich" follows the XOR key, when XORing the Rich header data, the start can be identified by "DanS" in ASCII and 3 null bytes for padding into a 16-byte paragraph. 

Current analysis decrypts the whole thing as it assumes there is no other data than Rich header there and then checks if there is "DanS" at the start. This doesn't behave correctly if there is any other "junk" data before the Rich header as it will decrypt it as well as is the case in #960 and just reports warning about wrong key because it didn't find the "DanS" at the start. I've changed the algorithm so it starts decrypting from the end ("Rich") to the top until it finds the "DanS" that marks the start of the Rich header, this seems to work well for both samples 

 - 2acd2ff9c70ba9398221cf2265b2fddaceae3e31a29883594bcce545f02be6a3
 - 7f29a26f830eee42a80a1a35169d9f616ca9823e386316f5eccfe36f90a8fe4b

But this means that the Rich header offset can vary based on the junk data, but this isn't really supported by the current RetDec code structure, so I'll need to edit that so we return the correct offset.

Checklist for PR:
- [x] Fix the analysis algorithm
- [x] Propagate correct offset from the Rich header analysis
- [x] Add test case into the regression test suite