### PR TITLE
Add sanity check for length of a PE resource type name

### DIFF
--- a/src/pelib/ResourceDirectory.cpp
+++ b/src/pelib/ResourceDirectory.cpp
@@ -731,7 +731,8 @@ namespace PeLib
 					imageLoader.readImage(&length, name_rva, sizeof(std::uint16_t));
 
 					// Sanity check for pointer to junk data instead of valid string
-					if (length <= 100) {
+					if (length <= 100)
+					{
 						// Read the resource name
 						imageLoader.readStringRc(rc.entry.wstrName, name_rva);
 					}

--- a/src/pelib/ResourceDirectory.cpp
+++ b/src/pelib/ResourceDirectory.cpp
@@ -725,8 +725,16 @@ namespace PeLib
 						return ERROR_INVALID_FILE;
 					}
 
-					// Read the resource name
-					imageLoader.readStringRc(rc.entry.wstrName, uiRsrcRva + uiNameOffset);
+					std::uint16_t length = 0;
+					std::uint32_t name_rva = uiRsrcRva + uiNameOffset;
+					// Read the string length (first 2 bytes at start)
+					imageLoader.readImage(&length, name_rva, sizeof(std::uint16_t));
+
+					// Sanity check for pointer to junk data instead of valid string
+					if (length <= 100) {
+						// Read the resource name
+						imageLoader.readStringRc(rc.entry.wstrName, name_rva);
+					}
 				}
 			}
 


### PR DESCRIPTION
Aims to fix #959 

Sometimes the type name pointer points to (probably?) junk data, which results in a string with absurd length and content. A simple sanity check on the string length could solve this problem.

As in example `097a0f8b8c3f2b90f5360f27da5ef8e5a7406c6f211c8d3e56a1671933508bc1`. More details can be seen in the mentioned issue.

If this solution is "OK", I'll add a test case in regression test suite.