### PR TITLE
Add oneline subject/issuer to the output

### DIFF
--- a/include/retdec/fileformat/types/certificate_table/certificate.h
+++ b/include/retdec/fileformat/types/certificate_table/certificate.h
@@ -46,7 +46,9 @@ class Certificate
 		std::string sha1Digest;
 		std::string sha256Digest;
 		std::string subjectRaw;
+		std::string subjectOneline;
 		std::string issuerRaw;
+		std::string issuerOneline;
 		Attributes subject;
 		Attributes issuer;
 
@@ -63,6 +65,8 @@ class Certificate
 		const std::string& getSha256Digest() const;
 		const std::string& getRawSubject() const;
 		const std::string& getRawIssuer() const;
+		const std::string& getOnelineSubject() const;
+		const std::string& getOnelineIssuer() const;
 		const Certificate::Attributes& getSubject() const;
 		const Certificate::Attributes& getIssuer() const;
 		/// @}

--- a/src/fileformat/file_format/pe/authenticode/x509_certificate.cpp
+++ b/src/fileformat/file_format/pe/authenticode/x509_certificate.cpp
@@ -235,11 +235,29 @@ std::string X509Certificate::getRawIssuer() const
 	return X509NameToString(X509_get_issuer_name(cert));
 }
 
+// Oneline version for YARA compatibility
+std::string X509Certificate::getOnelineSubject() const
+{
+	char buffer[256] = {0};
+	X509_NAME_oneline(X509_get_subject_name(cert), buffer, sizeof(buffer));
+	return std::string(buffer);
+}
+
+// Oneline version for YARA compatibility
+std::string X509Certificate::getOnelineIssuer() const
+{
+	char buffer[256] = {0};
+	X509_NAME_oneline(X509_get_issuer_name(cert), buffer, sizeof(buffer));
+	return std::string(buffer);
+}
+
 Certificate X509Certificate::createCertificate() const
 {
 	Certificate out_cert;
 	out_cert.issuerRaw = getRawIssuer();
+	out_cert.issuerOneline = getOnelineIssuer();
 	out_cert.subjectRaw = getRawSubject();
+	out_cert.subjectOneline = getOnelineSubject();
 	out_cert.issuer = getIssuer();
 	out_cert.subject = getSubject();
 	out_cert.publicKey = getPublicKey();

--- a/src/fileformat/file_format/pe/authenticode/x509_certificate.h
+++ b/src/fileformat/file_format/pe/authenticode/x509_certificate.h
@@ -44,6 +44,8 @@ public:
 	std::string getValidSince() const;
 	std::string getRawSubject() const;
 	std::string getRawIssuer() const;
+	std::string getOnelineSubject() const;
+	std::string getOnelineIssuer() const;
 	std::string getSerialNumber() const;
 	std::string getSignatureAlgorithm() const;
 	std::string getPublicKey() const;

--- a/src/fileformat/types/certificate_table/certificate.cpp
+++ b/src/fileformat/types/certificate_table/certificate.cpp
@@ -107,6 +107,14 @@ const std::string& Certificate::getRawIssuer() const
 	return issuerRaw;
 }
 
+const std::string& Certificate::getOnelineSubject() const
+{
+	return subjectOneline;
+}
+const std::string& Certificate::getOnelineIssuer() const
+{
+	return issuerOneline;
+}
 /**
  * Get subject of certificate in form of attributes
  * @return Subject of certificate

--- a/src/fileinfo/file_presentation/json_presentation.cpp
+++ b/src/fileinfo/file_presentation/json_presentation.cpp
@@ -396,6 +396,8 @@ void WriteCertificateChain(JsonPresentation::Writer& writer, const std::vector<C
 		writer.StartObject();
 		serializeString(writer, "subject", cert.getRawSubject());
 		serializeString(writer, "issuer", cert.getRawIssuer());
+		serializeString(writer, "subjectOneline", cert.getOnelineSubject());
+		serializeString(writer, "issuerOneline", cert.getOnelineIssuer());
 		serializeString(writer, "serialNumber", cert.getSerialNumber());
 		serializeString(writer, "publicKeyAlgorithm", cert.getPublicKeyAlgorithm());
 		serializeString(writer, "signatureAlgorithm", cert.getSignatureAlgorithm());;


### PR DESCRIPTION
Fixes #956 

I've added the subject/issuer oneline variant to the JSON output