### PR TITLE
Increased PE symbols MAX_LENGTH limits

### DIFF
--- a/include/retdec/pelib/PeLibAux.h
+++ b/include/retdec/pelib/PeLibAux.h
@@ -1127,8 +1127,8 @@ namespace PeLib
 		}
 	};
 
-	const std::size_t IMPORT_LIBRARY_MAX_LENGTH = 96;
-	const std::size_t IMPORT_SYMBOL_MAX_LENGTH = 96;
+	const std::size_t IMPORT_LIBRARY_MAX_LENGTH = 256;
+	const std::size_t IMPORT_SYMBOL_MAX_LENGTH = 256;
 
 	struct PELIB_IMAGE_RESOURCE_DATA_ENTRY
 	{
@@ -1242,7 +1242,7 @@ namespace PeLib
 */
 
 	const unsigned int PELIB_IMAGE_SIZEOF_COFF_SYMBOL = 18;
-	const std::size_t COFF_SYMBOL_NAME_MAX_LENGTH = 96;
+	const std::size_t COFF_SYMBOL_NAME_MAX_LENGTH = 256;
 
 	struct PELIB_IMAGE_COFF_SYMBOL
 	{

--- a/src/pelib/CoffSymbolTable.cpp
+++ b/src/pelib/CoffSymbolTable.cpp
@@ -42,7 +42,8 @@ namespace PeLib
 				{
 					for (std::size_t j = NameOffset; j < stringTableSize && stringTable[j] != '\0'; ++j)
 					{
-						// If we have symbol name with length of 96 and it contains non-printable character, stop there because it does not seem to be valid.
+						// If we have symbol name with length of COFF_SYMBOL_NAME_MAX_LENGTH and it
+						// contains non-printable character, stop there because it does not seem to be valid.
 						if (j - NameOffset == COFF_SYMBOL_NAME_MAX_LENGTH)
 						{
 							auto nonPrintableChars = std::count_if(symbol.Name.begin(), symbol.Name.end(), [](unsigned char c) { return !isprint(c); });


### PR DESCRIPTION
Fixes #957 

It seems there are 3 constants in the header:
- IMPORT_LIBRARY_MAX_LENGTH
- IMPORT_SYMBOL_MAX_LENGTH
- COFF_SYMBOL_NAME_MAX_LENGTH

I was wondering why isn't there a constant for exported symbols. It seems that for exported symbols there is no "sanity" length cap, it's capped by the default max value of the `read()` function (which is used to read the string from the image) which is 65535. I haven't seen any other MAX length constants in the pelib headers.

Based on the example binary I've raised those 3 constants to 256.