### PR TITLE
Change the section name parsing to only remove trailing zeroes

### DIFF
--- a/src/pelib/ImageLoader.cpp
+++ b/src/pelib/ImageLoader.cpp
@@ -4,6 +4,7 @@
  * @copyright (c) 2020 Avast Software, licensed under the MIT license
  */
 
+#include <algorithm>
 #include <iostream>
 #include <fstream>
 
@@ -1842,16 +1843,19 @@ int PeLib::ImageLoader::captureSectionName(
 
 	// The section name is directly in the section header.
 	// It has fixed length and must not be necessarily terminated with zero.
-	// Historically, PELIB copies the name of the section WITHOUT zero chars,
-	// even if the zero chars are in the middle. Aka ".text\0\0X" results in ".textX"
 	sectionName.clear();
-	for(size_t i = 0; i < PELIB_IMAGE_SIZEOF_SHORT_NAME; i++)
-	{
-		if(Name[i])
-		{
-			sectionName += Name[i];
-		}
+
+	// rstrip trailing nulls
+	const uint8_t* end = Name + PELIB_IMAGE_SIZEOF_SHORT_NAME;
+	// find the first non-null from end
+	do {
+		end--;
+	} while (end - Name > 0 && *end == 0);
+
+	if (end - Name > 0) {
+		sectionName.assign(Name, end + 1);
 	}
+
 	return ERROR_NONE;
 }
 

--- a/src/pelib/ImageLoader.cpp
+++ b/src/pelib/ImageLoader.cpp
@@ -4,7 +4,6 @@
  * @copyright (c) 2020 Avast Software, licensed under the MIT license
  */
 
-#include <algorithm>
 #include <iostream>
 #include <fstream>
 

--- a/src/pelib/ImageLoader.cpp
+++ b/src/pelib/ImageLoader.cpp
@@ -1847,11 +1847,13 @@ int PeLib::ImageLoader::captureSectionName(
 	// rstrip trailing nulls
 	const uint8_t* end = Name + PELIB_IMAGE_SIZEOF_SHORT_NAME;
 	// find the first non-null from end
-	do {
+	do
+	{
 		end--;
 	} while (end - Name > 0 && *end == 0);
 
-	if (end - Name > 0) {
+	if (end - Name > 0)
+	{
 		sectionName.assign(Name, end + 1);
 	}
 


### PR DESCRIPTION
Fixes #958 

The removal of all NULL chars in the pelib was intentional as in the comment: 
```
	// Historically, PELIB copies the name of the section WITHOUT zero chars,
	// even if the zero chars are in the middle. Aka ".text\0\0X" results in ".textX"
```
Not sure what was the reason, but based on the issue, I've changed the parsing to strip only the trailing zeroes.