### PR TITLE
Fix PE resource memory leak due to missing virtual destructor.

### DIFF
--- a/include/retdec/fileformat/types/resource_table/resource.h
+++ b/include/retdec/fileformat/types/resource_table/resource.h
@@ -42,6 +42,7 @@ class Resource
 		bool sublanguageIdIsValid = false; ///< @c true if sublanguage ID is valid
 		bool loaded = false;               ///< @c true if content of resource was successfully loaded from input file
 	public:
+		virtual ~Resource() = default;
 		/// @name Getters
 		/// @{
 		std::string getCrc32() const;


### PR DESCRIPTION
Fixes #951 

Add virtual destructor for Resource class so the deletion of classes that inherit from Resource, when hidden behind pointer to the parent class, can be correctly freed.