### PR TITLE
Modified AutoHotKey's Yara rule

### DIFF
--- a/support/yara_patterns/tools/pe/x64/compilers.yara
+++ b/support/yara_patterns/tools/pe/x64/compilers.yara
@@ -143,17 +143,26 @@ rule autohotkey_uv_01 {
 		language = "AutoHotKey"
 		bytecode = true
 	strings:
-		$1 = ">AUTOHOTKEY SCRIPT<"
-		$2 = ">AUTOHOTKEY SCRIPT<" wide
-	condition:
-		pe.is_64bit() and
-		for 1 of them : (
-			@ > pe.sections[pe.section_index(".rdata")].raw_data_offset and
-			@ < pe.sections[pe.section_index(".rdata")].raw_data_offset +
-			pe.sections[pe.section_index(".rdata")].raw_data_size
-		) or
-		for 1 i in (0 .. pe.number_of_resources) : (
-			pe.resources[i].name_string matches />AUTOHOTKEY SCRIPT</
+		$0 = "Hotkeys/hotstrings are not allowed inside functions." wide ascii
+		$1 = "IfWin should be #IfWin." wide ascii
+		$2 = "This hotstring is missing its abbreviation." wide ascii
+		$3 = "Duplicate hotkey." wide ascii
+		$4 = ">AUTOHOTKEY SCRIPT<" wide ascii
+    condition:
+        pe.is_64bit() 
+		and 
+		pe.number_of_resources > 0 
+		and ((
+					(@4 > pe.sections[pe.section_index(".rdata")].raw_data_offset 
+					and
+					@4 < pe.sections[pe.section_index(".rdata")].raw_data_offset +
+					pe.sections[pe.section_index(".rdata")].raw_data_size) 
+				or
+				(for 1 i in (0 .. pe.number_of_resources) : (
+					pe.resources[i].name_string matches />AUTOHOTKEY SCRIPT</))
+			)
+			or 
+			(3 of ($0,$1,$2,$3))
 		)
 }
 

--- a/support/yara_patterns/tools/pe/x86/compilers.yara
+++ b/support/yara_patterns/tools/pe/x86/compilers.yara
@@ -254,17 +254,26 @@ rule autohotkey_uv_01 {
 		language = "AutoHotKey"
 		bytecode = true
 	strings:
-		$1 = ">AUTOHOTKEY SCRIPT<"
-		$2 = ">AUTOHOTKEY SCRIPT<" wide
-	condition:
-		pe.is_32bit() and
-		for 1 of them : (
-			@ > pe.sections[pe.section_index(".rdata")].raw_data_offset and
-			@ < pe.sections[pe.section_index(".rdata")].raw_data_offset +
-			pe.sections[pe.section_index(".rdata")].raw_data_size
-		) or
-		for 1 i in (0 .. pe.number_of_resources) : (
-			pe.resources[i].name_string matches />AUTOHOTKEY SCRIPT</
+		$0 = "Hotkeys/hotstrings are not allowed inside functions." wide ascii
+		$1 = "IfWin should be #IfWin." wide ascii
+		$2 = "This hotstring is missing its abbreviation." wide ascii
+		$3 = "Duplicate hotkey." wide ascii
+		$4 = ">AUTOHOTKEY SCRIPT<" wide ascii
+    condition:
+        pe.is_32bit() 
+		and 
+		pe.number_of_resources > 0 
+		and ((
+					(@4 > pe.sections[pe.section_index(".rdata")].raw_data_offset 
+					and
+					@4 < pe.sections[pe.section_index(".rdata")].raw_data_offset +
+					pe.sections[pe.section_index(".rdata")].raw_data_size) 
+				or
+				(for 1 i in (0 .. pe.number_of_resources) : (
+					pe.resources[i].name_string matches />AUTOHOTKEY SCRIPT</))
+			)
+			or 
+			(3 of ($0,$1,$2,$3))
 		)
 }
 


### PR DESCRIPTION
The [Ahk2Exe](https://github.com/AutoHotkey/Ahk2Exe/blob/d9ce9212bda26640811690257928b77424988be8/BinMod.ahk#L23) compiler allows to change the name of the section ">AUTOHOTKEY SCRIPT<" with an arbitrary string.

The proposed rule adds the check on some strings from the embedded interpreter.

Example of sample escaping the previous rule: [09e7d7d9312f8a02e70690a96015136bdeed63dd0f115ab1293091affeba8661](https://www.virustotal.com/gui/file/09e7d7d9312f8a02e70690a96015136bdeed63dd0f115ab1293091affeba8661)