### PR TITLE
Modified Visual Basic's Yara rule

### DIFF
--- a/support/yara_patterns/tools/pe/x86/compilers.yara
+++ b/support/yara_patterns/tools/pe/x86/compilers.yara
@@ -1951,89 +1951,22 @@ rule ms_fortran {
 		$1 at pe.entry_point
 }
 
-rule ms_visual_basic_50_60_01 {
+rule ms_visual_basic_60 {
 	meta:
 		tool = "C"
 		name = "Microsoft Visual Basic"
-		version = "5.0 - 6.0"
-		pattern = "68????????E8????????00000000000030000000"
-	strings:
-		$1 = { 68 ?? ?? ?? ?? E8 ?? ?? ?? ?? 00 00 00 00 00 00 30 00 00 00 }
-	condition:
-		$1 at pe.entry_point
+		version = "6.0"
+    condition:
+		pe.imports("msvbvm60.dll", 100) or pe.imports("msvbvm60.dll", "ThunRTMain")
 }
 
-rule ms_visual_basic_50_60_02 {
-	meta:
-		tool = "C"
-		name = "Microsoft Visual Basic"
-		version = "5.0 - 6.0"
-		pattern = "FF25????????????68????????E8??FFFFFF"
-	strings:
-		$1 = { FF 25 ?? ?? ?? ?? ?? ?? 68 ?? ?? ?? ?? E8 ?? FF FF FF }
-	condition:
-		$1 at pe.entry_point
-}
-
-rule ms_visual_basic_50_01 {
+rule ms_visual_basic_50 {
 	meta:
 		tool = "C"
 		name = "Microsoft Visual Basic"
 		version = "5.0"
-		pattern = "FFFFFF0000000000003000000040000000000000"
-		start = 7
-	strings:
-		$1 = { FF FF FF 00 00 00 00 00 00 30 00 00 00 40 00 00 00 00 00 00 }
 	condition:
-		$1 at pe.entry_point + 7
-}
-
-rule ms_visual_basic_50_02 {
-	meta:
-		tool = "C"
-		name = "Microsoft Visual Basic"
-		version = "5.0"
-		pattern = "FFFFFF0000000000003000000040000000000000"
-	strings:
-		$1 = { FF FF FF 00 00 00 00 00 00 30 00 00 00 40 00 00 00 00 00 00 }
-	condition:
-		$1 at pe.entry_point
-}
-
-rule ms_visual_basic_60_01 {
-	meta:
-		tool = "C"
-		name = "Microsoft Visual Basic"
-		version = "6.0"
-		pattern = "5A68????????68????????52E9????FF"
-	strings:
-		$1 = { 5A 68 ?? ?? ?? ?? 68 ?? ?? ?? ?? 52 E9 ?? ?? FF }
-	condition:
-		$1 at pe.entry_point
-}
-
-rule ms_visual_basic_60_02 {
-	meta:
-		tool = "C"
-		name = "Microsoft Visual Basic"
-		version = "6.0"
-		pattern = "5A68????????68????????52E9????????000000??00000030000000??000000??000000"
-	strings:
-		$1 = { 5A 68 ?? ?? ?? ?? 68 ?? ?? ?? ?? 52 E9 ?? ?? ?? ?? 00 00 00 ?? 00 00 00 30 00 00 00 ?? 00 00 00 ?? 00 00 00 }
-	condition:
-		$1 at pe.entry_point
-}
-
-rule ms_visual_basic_60_03 {
-	meta:
-		tool = "C"
-		name = "Microsoft Visual Basic"
-		version = "6.0"
-		pattern = "FF25????????68????????E8??FFFFFF????????????30"
-	strings:
-		$1 = { FF 25 ?? ?? ?? ?? 68 ?? ?? ?? ?? E8 ?? FF FF FF ?? ?? ?? ?? ?? ?? 30 }
-	condition:
-		$1 at pe.entry_point
+		pe.imports("msvbvm50.dll", 100) or pe.imports("msvbvm50.dll", "ThunRTMain")
 }
 
 rule dotnet_01 {


### PR DESCRIPTION
The _ThunRTMain_ function is the one needed to startup a Visual Basic app (can be imported via ordinal), so if it's a VB executable is required to import it.

In addition, the use of ? wildcard may slow down the scanning.