### PR TITLE
Fix of .NET analysis differences

### DIFF
--- a/include/retdec/fileformat/types/dotnet_headers/blob_stream.h
+++ b/include/retdec/fileformat/types/dotnet_headers/blob_stream.h
@@ -7,6 +7,7 @@
 #ifndef RETDEC_FILEFORMAT_TYPES_DOTNET_HEADERS_BLOB_STREAM_H
 #define RETDEC_FILEFORMAT_TYPES_DOTNET_HEADERS_BLOB_STREAM_H
 
+#include <cstdint>
 #include <unordered_map>
 
 #include "retdec/fileformat/types/dotnet_headers/stream.h"
@@ -17,19 +18,11 @@ namespace fileformat {
 class BlobStream : public Stream
 {
 	private:
-		std::unordered_map<std::size_t, std::vector<std::uint8_t>> elements;
+		std::vector<std::uint8_t> data;
 	public:
-		BlobStream(std::uint64_t streamOffset, std::uint64_t streamSize);
+		BlobStream(std::vector<std::uint8_t> data, std::uint64_t streamOffset, std::uint64_t streamSize);
 
-		/// @name Getters
-		/// @{
 		std::vector<std::uint8_t> getElement(std::size_t offset) const;
-		/// @}
-
-		/// @name Element methods
-		/// @{
-		void addElement(std::size_t offset, const std::vector<std::uint8_t>& data);
-		/// @}
 };
 
 } // namespace fileformat

--- a/include/retdec/fileformat/types/dotnet_headers/metadata_tables.h
+++ b/include/retdec/fileformat/types/dotnet_headers/metadata_tables.h
@@ -651,6 +651,9 @@ struct TypeDef : public BaseRecord
 	bool isNestedPublic() const { return (flags & TypeVisibilityMask) == TypeNestedPublic; }
 	bool isNestedPrivate() const { return (flags & TypeVisibilityMask) == TypeNestedPrivate; }
 	bool isNestedProtected() const { return (flags & TypeVisibilityMask) == TypeNestedFamily; }
+	bool isNestedInternal() const { return (flags & TypeVisibilityMask) == TypeNestedAssembly; }
+	bool isNestedFamOrAssem() const { return (flags & TypeVisibilityMask) == TypeNestedFamORAssem; }
+	bool isNestedFamAndAssem() const { return (flags & TypeVisibilityMask) == TypeNestedFamANDAssem; }
 	bool isClass() const { return (flags & TypeClassSemanticsMask) == TypeClass; }
 	bool isInterface() const { return (flags & TypeClassSemanticsMask) == TypeInterface; }
 	bool isAbstract() const { return flags & TypeClassAbstract; }
@@ -688,6 +691,9 @@ struct Field : public BaseRecord
 	bool isPublic() const { return (flags & FieldAccessMask) == FieldPublic; }
 	bool isProtected() const { return (flags & FieldAccessMask) == FieldFamily; }
 	bool isPrivate() const { return (flags & FieldAccessMask) == FieldPrivate; }
+	bool isInternal() const { return (flags & FieldAccessMask) == FieldAssembly; }
+	bool isFamOrAssem() const { return (flags & FieldAccessMask) == FieldFamORAssem; }
+	bool isFamAndAssem() const { return (flags & FieldAccessMask) == FieldFamANDAssem; }
 	bool isStatic() const { return flags & FieldStatic; }
 
 	virtual void load(const FileFormat* file, const MetadataStream* stream, std::uint64_t& address) override
@@ -720,6 +726,10 @@ struct MethodDef : public BaseRecord
 	bool isPublic() const { return (flags & MethodMemberAccessMask) == MethodPublic; }
 	bool isPrivate() const { return (flags & MethodMemberAccessMask) == MethodPrivate; }
 	bool isProtected() const { return (flags & MethodMemberAccessMask) == MethodFamily; }
+	bool isInternal() const { return (flags & MethodMemberAccessMask) == MethodAssem; }
+	bool isFamOrAssem() const { return (flags & MethodMemberAccessMask) == MethodFamORAssem; }
+	bool isFamAndAssem() const { return (flags & MethodMemberAccessMask) == MethodFamANDAssem; }
+
 	bool isStatic() const { return flags & MethodStatic; }
 	bool isVirtual() const { return flags & MethodVirtual; }
 	bool isFinal() const { return flags & MethodFinal; }

--- a/include/retdec/fileformat/types/dotnet_types/dotnet_class.h
+++ b/include/retdec/fileformat/types/dotnet_types/dotnet_class.h
@@ -94,6 +94,7 @@ class DotnetClass : public DotnetType
 		bool isInterface() const;
 		bool isAbstract() const;
 		bool isSealed() const;
+		bool isNested() const;
 		/// @}
 
 		/// @name Additions

--- a/include/retdec/fileformat/types/dotnet_types/dotnet_type.h
+++ b/include/retdec/fileformat/types/dotnet_types/dotnet_type.h
@@ -19,8 +19,11 @@ namespace fileformat {
 enum class DotnetTypeVisibility
 {
 	Public,
+	Internal,
+	Private,
 	Protected,
-	Private
+	ProtectedInternal,
+	PrivateProtected
 };
 
 /**
@@ -56,6 +59,9 @@ class DotnetType
 		bool isPublic() const { return visibility == DotnetTypeVisibility::Public; }
 		bool isProtected() const { return visibility == DotnetTypeVisibility::Protected; }
 		bool isPrivate() const { return visibility == DotnetTypeVisibility::Private; }
+		bool isInternal() const { return visibility == DotnetTypeVisibility::Internal; }
+		bool isProtectedInternal() const { return visibility == DotnetTypeVisibility::ProtectedInternal; }
+		bool isPrivateProtected() const { return visibility == DotnetTypeVisibility::PrivateProtected; }
 		/// @}
 };
 

--- a/include/retdec/fileformat/types/dotnet_types/dotnet_type_reconstructor.h
+++ b/include/retdec/fileformat/types/dotnet_types/dotnet_type_reconstructor.h
@@ -50,7 +50,7 @@ class DotnetTypeReconstructor
 		std::unique_ptr<DotnetField> createField(const Field* field, const DotnetClass* ownerClass);
 		std::unique_ptr<DotnetProperty> createProperty(const Property* property, const DotnetClass* ownerClass);
 		std::unique_ptr<DotnetMethod> createMethod(const MethodDef* methodDef, const DotnetClass* ownerClass);
-		std::unique_ptr<DotnetParameter> createMethodParameter(const Param* param, const DotnetClass* ownerClass, const DotnetMethod* ownerMethod, std::vector<std::uint8_t>& signature);
+		std::unique_ptr<DotnetParameter> createMethodParameter(std::size_t paramIdx, std::size_t startIdx, const DotnetClass* ownerClass, const DotnetMethod* ownerMethod, std::vector<std::uint8_t>& signature);
 
 		template <typename T> std::unique_ptr<T> createDataTypeFollowedByReference(std::vector<std::uint8_t>& data);
 		template <typename T> std::unique_ptr<T> createDataTypeFollowedByType(std::vector<std::uint8_t>& data, const DotnetClass* ownerClass, const DotnetMethod* ownerMethod);

--- a/src/fileformat/file_format/pe/pe_format.cpp
+++ b/src/fileformat/file_format/pe/pe_format.cpp
@@ -3160,10 +3160,12 @@ bool PeFormat::isDotNet() const
 
 	std::uint32_t numberOfRvaAndSizes = getImageLoader().getOptionalHeader().NumberOfRvaAndSizes;
 	// If the binary is 64bit, check NumberOfRvaAndSizes, otherwise don't
-	if (getImageBitability() == 64 &&
-			numberOfRvaAndSizes < PELIB_IMAGE_DIRECTORY_ENTRY_COM_DESCRIPTOR)
+	if (getImageBitability() == 64)
 	{
-		return false;
+		if (numberOfRvaAndSizes < PELIB_IMAGE_DIRECTORY_ENTRY_COM_DESCRIPTOR)
+		{
+			return false;
+		}
 	}
 	else if (!isDll())
 	{ // If 32 bit check if first 2 bytes at entry point are 0xFF 0x25

--- a/src/fileformat/file_format/pe/pe_format.cpp
+++ b/src/fileformat/file_format/pe/pe_format.cpp
@@ -1924,15 +1924,15 @@ void PeFormat::loadDotnetHeaders()
 			return;
 		}
 
-		if (streamName == "#~" || streamName == "#-")
+		if ((streamName == "#~" || streamName == "#-") && !metadataStream)
 			parseMetadataStream(metadataHeaderAddress, streamOffset, streamSize);
-		else if (streamName == "#Blob")
+		else if (streamName == "#Blob" && !blobStream)
 			parseBlobStream(metadataHeaderAddress, streamOffset, streamSize);
-		else if (streamName == "#GUID")
+		else if (streamName == "#GUID" && !guidStream)
 			parseGuidStream(metadataHeaderAddress, streamOffset, streamSize);
-		else if (streamName == "#Strings")
+		else if (streamName == "#Strings" && !stringStream)
 			parseStringStream(metadataHeaderAddress, streamOffset, streamSize);
-		else if (streamName == "#US")
+		else if (streamName == "#US" && !userStringStream)
 			parseUserStringStream(metadataHeaderAddress, streamOffset, streamSize);
 
 		// Round-up to the nearest higher multiple of 4

--- a/src/fileformat/file_format/pe/pe_format.cpp
+++ b/src/fileformat/file_format/pe/pe_format.cpp
@@ -2224,7 +2224,7 @@ void PeFormat::parseBlobStream(std::uint64_t baseAddress, std::uint64_t offset, 
 	std::vector<std::uint8_t> data;
 	auto address = baseAddress + offset;
 	getXBytes(address, size, data);
-	blobStream = std::make_unique<BlobStream>(data, offset, size);
+	blobStream = std::make_unique<BlobStream>(std::move(data), offset, size);
 
 }
 
@@ -3152,7 +3152,7 @@ bool PeFormat::isDotNet() const
 		return false;
 	}
 
-	unsigned correctHdrSize = 72;
+	std::uint32_t correctHdrSize = 72;
 	if (clrHeader->getHeaderSize() != correctHdrSize)
 	{
 		return false;

--- a/src/fileformat/file_format/pe/pe_format.cpp
+++ b/src/fileformat/file_format/pe/pe_format.cpp
@@ -2060,6 +2060,13 @@ void PeFormat::parseMetadataStream(std::uint64_t baseAddress, std::uint64_t offs
 			currentAddress += 4;
 		}
 	}
+	// ExtraData flags means there is extra 4 bytes at the end Rows array that contaisn the rows sizes
+	// I don't see anything about in at ECMA-335, but I can see in real samples and in IlSpy source
+	// that understands it and correctly decompiles, sample: 5b5817fe2d4f0989501802b0e2bb4451583ff27fd0723f40bb7f8b0417dd7c58
+	if (heapOffsetSizes & 0x40)
+	{
+		currentAddress += 4;
+	}
 
 	for (std::size_t i = 0; i < 64; ++i)
 	{

--- a/src/fileformat/file_format/pe/pe_format.cpp
+++ b/src/fileformat/file_format/pe/pe_format.cpp
@@ -2306,14 +2306,8 @@ void PeFormat::parseStringStream(std::uint64_t baseAddress, std::uint64_t offset
 	while (currentOffset < size)
 	{
 		std::string string;
-		if (!getNTBS(address + currentOffset, string))
-		{
-			currentOffset += 1;
-			continue;
-		}
-
+		getNTBS(address + currentOffset, string);
 		stringStream->addString(currentOffset, string);
-
 		// +1 for null-terminator
 		currentOffset += 1 + string.length();
 	}

--- a/src/fileformat/types/dotnet_headers/blob_stream.cpp
+++ b/src/fileformat/types/dotnet_headers/blob_stream.cpp
@@ -11,7 +11,7 @@ namespace retdec {
 namespace fileformat {
 
 BlobStream::BlobStream(std::vector<std::uint8_t> data, std::uint64_t streamOffset, std::uint64_t streamSize)
-	: Stream(StreamType::Blob, streamOffset, streamSize), data(data)
+	: Stream(StreamType::Blob, streamOffset, streamSize), data(std::move(data))
 {
 }
 

--- a/src/fileformat/types/dotnet_headers/blob_stream.cpp
+++ b/src/fileformat/types/dotnet_headers/blob_stream.cpp
@@ -39,7 +39,10 @@ std::vector<std::uint8_t> BlobStream::getElement(std::size_t offset) const
 	{
 		len = *ptr;
 		offset += 1;
-		res.assign(data.begin() + offset, data.begin() + offset + len);
+		if (offset + len <= data.size())
+		{
+			res.assign(data.begin() + offset, data.begin() + offset + len);
+		}
 	}
 	else if ((*ptr & 0xC0) == 0x80)
 	{
@@ -50,22 +53,27 @@ std::vector<std::uint8_t> BlobStream::getElement(std::size_t offset) const
 			len = ((*ptr & 0x3F) << 8) | *(ptr + 1);
 			offset += 2;
 		}
-
-		res.assign(data.begin() + offset, data.begin() + offset + len);
+		if (offset + len <= data.size())
+		{
+			res.assign(data.begin() + offset, data.begin() + offset + len);
+		}
 	}
 	else if ((*ptr & 0xE0) == 0xC0)
 	{
 		// Make sure we have 3 more bytes.
-		if (offset + 2 < data.size())
+		if (offset + 3 < data.size())
 		{
 			// Shift remaining 6 bits left by 8 and OR in the remaining byte.
 			len = ((*ptr & 0x1F) << 24) |
 					(*(ptr + 1) << 16) |
 					(*(ptr + 2) << 8) |
 					*(ptr + 3);
-			offset += 2;
+			offset += 4;
 		}
-		res.assign(data.begin() + offset, data.begin() + offset + len);
+		if (offset + len <= data.size())
+		{
+			res.assign(data.begin() + offset, data.begin() + offset + len);
+		}
 	}
 
 	return res;

--- a/src/fileformat/types/dotnet_headers/blob_stream.cpp
+++ b/src/fileformat/types/dotnet_headers/blob_stream.cpp
@@ -29,11 +29,10 @@ std::vector<std::uint8_t> BlobStream::getElement(std::size_t offset) const
 {
 	// Ugly, C like just for fast prototype, rework TODO
 	std::uint32_t len = 0;
-	std::vector<std::uint8_t> res;
 	const unsigned char* ptr = data.data() + offset;
 	if (offset >= data.size())
 	{
-		return res;
+		return {};
 	}
 	else if ((*ptr & 0x80) == 0x00)
 	{
@@ -41,7 +40,7 @@ std::vector<std::uint8_t> BlobStream::getElement(std::size_t offset) const
 		offset += 1;
 		if (offset + len <= data.size())
 		{
-			res.assign(data.begin() + offset, data.begin() + offset + len);
+			return { data.begin() + offset, data.begin() + offset + len };
 		}
 	}
 	else if ((*ptr & 0xC0) == 0x80)
@@ -55,7 +54,7 @@ std::vector<std::uint8_t> BlobStream::getElement(std::size_t offset) const
 		}
 		if (offset + len <= data.size())
 		{
-			res.assign(data.begin() + offset, data.begin() + offset + len);
+			return { data.begin() + offset, data.begin() + offset + len };
 		}
 	}
 	else if ((*ptr & 0xE0) == 0xC0)
@@ -72,11 +71,11 @@ std::vector<std::uint8_t> BlobStream::getElement(std::size_t offset) const
 		}
 		if (offset + len <= data.size())
 		{
-			res.assign(data.begin() + offset, data.begin() + offset + len);
+			return { data.begin() + offset, data.begin() + offset + len };
 		}
 	}
 
-	return res;
+	return {};
 }
 } // namespace fileformat
 } // namespace retdec

--- a/src/fileformat/types/dotnet_headers/blob_stream.cpp
+++ b/src/fileformat/types/dotnet_headers/blob_stream.cpp
@@ -22,7 +22,8 @@ BlobStream::BlobStream(std::vector<std::uint8_t> data, std::uint64_t streamOffse
  */
 std::vector<std::uint8_t> BlobStream::getElement(std::size_t offset) const
 {
-	// Ugly, C like just for fast prototype, rework TODO
+	// Adapted from YARA
+	// https://github.com/VirusTotal/yara/blob/v4.1.2/libyara/modules/dotnet/dotnet.c#L130
 	std::uint32_t len = 0;
 	const unsigned char* ptr = data.data() + offset;
 	if (offset >= data.size())

--- a/src/fileformat/types/dotnet_headers/blob_stream.cpp
+++ b/src/fileformat/types/dotnet_headers/blob_stream.cpp
@@ -10,11 +10,6 @@
 namespace retdec {
 namespace fileformat {
 
-/**
- * Constructor.
- * @param streamOffset Stream offset.
- * @param streamSize Stream size.
- */
 BlobStream::BlobStream(std::vector<std::uint8_t> data, std::uint64_t streamOffset, std::uint64_t streamSize)
 	: Stream(StreamType::Blob, streamOffset, streamSize), data(data)
 {

--- a/src/fileformat/types/dotnet_headers/blob_stream.cpp
+++ b/src/fileformat/types/dotnet_headers/blob_stream.cpp
@@ -30,6 +30,11 @@ std::vector<std::uint8_t> BlobStream::getElement(std::size_t offset) const
 	{
 		return {};
 	}
+	// ECMA 335 II.24.2.4
+	/* Blob starts with their length in big-endian order 
+	which can be variable in size. We can figure out the 
+	size of the length using first few bits of the first byte. */
+	// If first bit is 0, length is encoded in the first byte
 	else if ((*ptr & 0x80) == 0x00)
 	{
 		len = *ptr;
@@ -39,6 +44,7 @@ std::vector<std::uint8_t> BlobStream::getElement(std::size_t offset) const
 			return { data.begin() + offset, data.begin() + offset + len };
 		}
 	}
+	// If first 2 bits are 10, length is stored in 2 bytes
 	else if ((*ptr & 0xC0) == 0x80)
 	{
 		// Make sure we have one more byte.
@@ -53,6 +59,7 @@ std::vector<std::uint8_t> BlobStream::getElement(std::size_t offset) const
 			return { data.begin() + offset, data.begin() + offset + len };
 		}
 	}
+	// If first 3 bits are 110, length is stored in 4 bytes
 	else if ((*ptr & 0xE0) == 0xC0)
 	{
 		// Make sure we have 3 more bytes.

--- a/src/fileformat/types/dotnet_types/dotnet_class.cpp
+++ b/src/fileformat/types/dotnet_types/dotnet_class.cpp
@@ -6,6 +6,7 @@
 
 #include "retdec/utils/string.h"
 #include "retdec/fileformat/types/dotnet_types/dotnet_class.h"
+#include <cstdint>
 
 using namespace retdec::utils;
 
@@ -410,6 +411,18 @@ bool DotnetClass::isAbstract() const
 bool DotnetClass::isSealed() const
 {
 	return sealed;
+}
+
+bool DotnetClass::isNested() const
+{
+	const TypeDef* row = getRawTypeDef();
+	if (!row)
+	{
+		return false;
+	}
+	std::uint32_t flags = getRawTypeDef()->flags;
+	return (flags & TypeVisibilityMask) != TypeNotPublic &&
+			(flags & TypeVisibilityMask) != TypePublic;
 }
 
 /**

--- a/src/fileformat/types/dotnet_types/dotnet_type.cpp
+++ b/src/fileformat/types/dotnet_types/dotnet_type.cpp
@@ -19,7 +19,10 @@ const std::unordered_map<DotnetTypeVisibility, std::string, retdec::utils::EnumC
 {
 	{ DotnetTypeVisibility::Public,    "public"    },
 	{ DotnetTypeVisibility::Protected, "protected" },
-	{ DotnetTypeVisibility::Private,   "private"   }
+	{ DotnetTypeVisibility::Private,   "private"   },
+	{ DotnetTypeVisibility::Internal,   "internal"   },
+	{ DotnetTypeVisibility::ProtectedInternal,   "protected internal"   },
+	{ DotnetTypeVisibility::PrivateProtected,   "private protected"   },
 };
 
 }

--- a/src/fileformat/types/dotnet_types/dotnet_type_reconstructor.cpp
+++ b/src/fileformat/types/dotnet_types/dotnet_type_reconstructor.cpp
@@ -518,7 +518,7 @@ bool DotnetTypeReconstructor::reconstructMethodParameters()
 			// Obtain postponed signature
 			// We now know all the information required for method parameters reconstruction
 			auto methodDef = method->getRawRecord();
-			auto signature = methodReturnTypeAndParamTypeTable[method.get()];
+			auto& signature = methodReturnTypeAndParamTypeTable[method.get()];
 
 			// Reconstruct return type
 			auto returnType = dataTypeFromSignature(signature, classType.get(), method.get());
@@ -1191,7 +1191,7 @@ std::unique_ptr<DotnetDataTypeArray> DotnetTypeReconstructor::createArray(std::v
 	// Some dimensions can have limited size by declaration
 	// Size 0 means not specified
 	std::uint64_t numOfSizes = decodeUnsigned(data, bytesRead);
-	if (bytesRead == 0)
+	if (bytesRead == 0 || numOfSizes > rank)
 		return nullptr;
 	data.erase(data.begin(), data.begin() + bytesRead);
 
@@ -1206,7 +1206,7 @@ std::unique_ptr<DotnetDataTypeArray> DotnetTypeReconstructor::createArray(std::v
 
 	// And some dimensions can also be limited by special lower bound
 	std::size_t numOfLowBounds = decodeUnsigned(data, bytesRead);
-	if (bytesRead == 0)
+	if (bytesRead == 0 || numOfLowBounds > rank)
 		return nullptr;
 	data.erase(data.begin(), data.begin() + bytesRead);
 

--- a/src/fileformat/types/dotnet_types/dotnet_type_reconstructor.cpp
+++ b/src/fileformat/types/dotnet_types/dotnet_type_reconstructor.cpp
@@ -656,7 +656,15 @@ bool DotnetTypeReconstructor::reconstructNestedClasses()
 		if (enclosingItr == defClassTable.end())
 			continue;
 
-		nestedItr->second->setNameSpace(enclosingItr->second->getFullyQualifiedName());
+		const std::string& namespac = nestedItr->second->getNameSpace();
+		if (namespac.empty())
+		{
+			nestedItr->second->setNameSpace(enclosingItr->second->getFullyQualifiedName());
+		}
+		else
+		{
+			nestedItr->second->setNameSpace(enclosingItr->second->getFullyQualifiedName() + "." + nestedItr->second->getNameSpace());
+		}
 	}
 
 	return true;

--- a/src/fileformat/types/dotnet_types/dotnet_type_reconstructor.cpp
+++ b/src/fileformat/types/dotnet_types/dotnet_type_reconstructor.cpp
@@ -652,7 +652,8 @@ bool DotnetTypeReconstructor::reconstructNestedClasses()
 		auto nestedClass = nestedClassTable->getRow(i);
 
 		auto nestedItr = defClassTable.find(nestedClass->nestedClass.getIndex());
-		if (nestedItr == defClassTable.end())
+		// Validate that the type is actually nested
+		if (nestedItr == defClassTable.end() || !nestedItr->second->isNested())
 			continue;
 
 		auto enclosingItr = defClassTable.find(nestedClass->enclosingClass.getIndex());

--- a/src/fileformat/types/dotnet_types/dotnet_type_reconstructor.cpp
+++ b/src/fileformat/types/dotnet_types/dotnet_type_reconstructor.cpp
@@ -176,6 +176,12 @@ DotnetTypeVisibility toTypeVisibility(const T* source)
 		return DotnetTypeVisibility::Protected;
 	else if (source->isPrivate())
 		return DotnetTypeVisibility::Private;
+	else if (source->isInternal())
+		return DotnetTypeVisibility::Internal;
+	else if (source->isFamOrAssem())
+		return DotnetTypeVisibility::ProtectedInternal;
+	else if (source->isFamAndAssem())
+		return DotnetTypeVisibility::PrivateProtected;
 	else
 		return DotnetTypeVisibility::Private;
 }
@@ -183,16 +189,21 @@ DotnetTypeVisibility toTypeVisibility(const T* source)
 template <>
 DotnetTypeVisibility toTypeVisibility<TypeDef>(const TypeDef* source)
 {
-	if (source->isPublic() || source->isNestedPublic())
-		return DotnetTypeVisibility::Public;
+	if (source->isNonPublic() || source->isNestedInternal())
+		return DotnetTypeVisibility::Internal;
 	else if (source->isNestedProtected())
 		return DotnetTypeVisibility::Protected;
-	else if (source->isNonPublic() || source->isNestedPrivate())
+	else if (source->isNestedPrivate())
 		return DotnetTypeVisibility::Private;
+	else if (source->isNestedFamAndAssem())
+		return DotnetTypeVisibility::PrivateProtected;
+	else if (source->isNestedFamOrAssem())
+		return DotnetTypeVisibility::ProtectedInternal;
+	else if (source->isNestedPublic() || source->isPublic())
+		return DotnetTypeVisibility::Public;
 	else
 		return DotnetTypeVisibility::Private;
 }
-
 }
 
 /**

--- a/src/fileformat/types/dotnet_types/dotnet_type_reconstructor.cpp
+++ b/src/fileformat/types/dotnet_types/dotnet_type_reconstructor.cpp
@@ -1016,7 +1016,8 @@ std::unique_ptr<DotnetMethod> DotnetTypeReconstructor::createMethod(const Method
 
 /**
  * Creates new method parameter from Param table record.
- * @param param Param table record.
+ * @param paramIdx Index of the current Param record
+ * @param startIdx Index of the first Param record of the method
  * @param ownerClass Owning class.
  * @param ownerMethod Owning method.
  * @param signature Signature with data types. Is destroyed in the meantime.

--- a/src/fileformat/types/dotnet_types/dotnet_type_reconstructor.cpp
+++ b/src/fileformat/types/dotnet_types/dotnet_type_reconstructor.cpp
@@ -1459,6 +1459,7 @@ const DotnetClass* DotnetTypeReconstructor::selectClass(const TypeDefOrRef& type
 
 		result = itr->second.get();
 	}
+	// TODO TypeSpec is missing here
 
 	return result;
 }


### PR DESCRIPTION
This PR is fixing several .NET parsing differences and bugs:

- [x] Type namespace creation for Nested types that also have a namespace
- [x] Parameter reconstruction from the signature only when Param information is missing
- [x] Fixing incorrect .NET visibility output
- [x] FileInfo not detecting any class information for some files
  - [x] Understand ExtraData flag in Metadata Stream header
  - [x] Use always the first instance of a stream type (sometimes samples have multiple of streams, but the first one is the valid one)
 - [x] Accept empty strings in StringHeap
 - [x] Rework BlobStream as there can be a valid blob stream at any offset
 - [x] Add bound checking when recreating arrays
 - [x] Add more checks to validate if the file is actually a .NET file