### PR TITLE
Switch to using Python3 module to detect a python

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,8 @@ include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/utils.cmake)
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/options.cmake)
 
 # RetDec, and some dependencies (e.g. LLVM, Keystone), require Python 3.
-find_package(PythonInterp 3.4 REQUIRED)
+find_package(Python3 3.4 REQUIRED)
+set(PYTHON_EXECUTABLE ${Python3_EXECUTABLE})
 
 ### Variables.
 


### PR DESCRIPTION
`PythonInterp` is old and deprecated module which may gave up on a system with multiple python installation like 2.7 and 3.x where `/usr/bin/python` is 2.7.