### PR TITLE
Fix master not building due to conflicting types

### DIFF
--- a/src/fileformat/file_format/pe/pe_format.cpp
+++ b/src/fileformat/file_format/pe/pe_format.cpp
@@ -3198,7 +3198,7 @@ bool PeFormat::isDotNet() const
 	else if (!isDll())
 	{ // If 32 bit check if first 2 bytes at entry point are 0xFF 0x25
 
-		unsigned long long entryAddr = 0;
+		std::uint64_t entryAddr = 0;
 		if (!getEpAddress(entryAddr))
 		{
 			return false;


### PR DESCRIPTION
Incompatible types `std::uint` and `unsigned long long` due to refactorization and incorrect merge conflict solution.