### PR TITLE
Use image loader when loading corrupted resources

### DIFF
--- a/src/fileformat/file_format/pe/pe_format.cpp
+++ b/src/fileformat/file_format/pe/pe_format.cpp
@@ -1650,7 +1650,7 @@ void PeFormat::loadResourceNodes(std::vector<const PeLib::ResourceChild*> &nodes
 			continue;
 		}
 		auto resource = std::make_unique<Resource>();
-		resource->setOffset(leaf->getOffsetToData() - rva + formatParser->getResourceDirectoryOffset());
+		resource->setOffset(getImageLoader().getValidOffsetFromRva(leaf->getOffsetToData()));
 		resource->setSizeInFile(leaf->getSize());
 		resource->load(this);
 		resourceTable->addResource(std::move(resource));


### PR DESCRIPTION
When the resource tree doesn't have expected depth, we use different
path to load resources which didn't use loader but calculated offset
from RVA on it's own resulting in underflows on integers and completely
bogus offsets. Even though offsets are still kinda bogus, they make
sense and are within the file itself after this change.

Example file: f39f1ad9f97766618826d47c2d32529425e773659f5577fea06a82e21f13b064