### PR TITLE
[tests][capstone2llvmir][arm] Fix Nop test

### DIFF
--- a/tests/capstone2llvmir/arm_tests.cpp
+++ b/tests/capstone2llvmir/arm_tests.cpp
@@ -1717,7 +1717,9 @@ TEST_P(Capstone2LlvmIrTranslatorArmTests, ARM_INS_NOP)
 
 	EXPECT_NO_REGISTERS_STORED();
 	EXPECT_NO_MEMORY_LOADED_STORED();
-	EXPECT_NO_VALUE_CALLED();
+	EXPECT_JUST_VALUES_CALLED({
+		{_module.getFunction("__asm_nop"), {}},
+	});
 }
 
 //


### PR DESCRIPTION
- In arm, the NOP instruction is HINT instruction
- Also, in capstone, the cs_insn->id of nop is point to HINT(ID: 63)
- So, an error will be occurred when looking for a translate instruction method because it is points to nullptr