### PR TITLE
Add dll name from export directory to output

### DIFF
--- a/include/retdec/fileformat/types/export_table/export_table.h
+++ b/include/retdec/fileformat/types/export_table/export_table.h
@@ -25,13 +25,20 @@ class ExportTable
 		std::string expHashCrc32;                   ///< exphash CRC32
 		std::string expHashMd5;                     ///< exphash MD5
 		std::string expHashSha256;                  ///< exphash SHA256
+		std::string dllName;
 	public:
+		/// @name Setters
+		/// @{
+		void setDllName(const std::string& dllName);
+		/// @}
+
 		/// @name Getters
 		/// @{
 		std::size_t getNumberOfExports() const;
 		const std::string& getExphashCrc32() const;
 		const std::string& getExphashMd5() const;
 		const std::string& getExphashSha256() const;
+		const std::string& getDllName() const;
 		const Export* getExport(std::size_t exportIndex) const;
 		const Export* getExport(const std::string &name) const;
 		const Export* getExportOnAddress(unsigned long long address) const;

--- a/src/fileformat/file_format/pe/pe_format.cpp
+++ b/src/fileformat/file_format/pe/pe_format.cpp
@@ -1542,6 +1542,8 @@ void PeFormat::loadExports()
 		exportTable->addExport(newExport);
 	}
 
+	exportTable->setDllName(formatParser->getExportDirectory().getNameString());
+
 	loadExpHash();
 
 	for(auto&& addressRange : formatParser->getExportDirectoryOccupiedAddresses())

--- a/src/fileformat/types/export_table/export_table.cpp
+++ b/src/fileformat/types/export_table/export_table.cpp
@@ -14,6 +14,11 @@ using namespace retdec::utils;
 namespace retdec {
 namespace fileformat {
 
+void ExportTable::setDllName(const std::string& dllName)
+{
+	this->dllName = dllName;
+}
+
 /**
  * Get number of stored exports
  * @return Number of stored exports
@@ -48,6 +53,11 @@ const std::string& ExportTable::getExphashMd5() const
 const std::string& ExportTable::getExphashSha256() const
 {
 	return expHashSha256;
+}
+
+const std::string& ExportTable::getDllName() const
+{
+	return dllName;
 }
 
 /**

--- a/src/fileinfo/file_information/file_information.cpp
+++ b/src/fileinfo/file_information/file_information.cpp
@@ -1340,6 +1340,11 @@ void FileInformation::setDepsListFailedToLoad(const std::string & depsList)
 	failedDepsList = depsList;
 }
 
+std::string FileInformation::getExportDllName() const
+{
+	return exportTable.getDllName();
+}
+
 /**
  * Get number of stored exports
  * @return Number of stored exports

--- a/src/fileinfo/file_information/file_information.h
+++ b/src/fileinfo/file_information/file_information.h
@@ -243,6 +243,7 @@ class FileInformation
 		/// @name Getters of @a exportTable
 		/// @{
 		std::size_t getNumberOfStoredExports() const;
+		std::string getExportDllName() const;
 		std::string getExphashCrc32() const;
 		std::string getExphashMd5() const;
 		std::string getExphashSha256() const;

--- a/src/fileinfo/file_information/file_information_types/export_table.cpp
+++ b/src/fileinfo/file_information/file_information_types/export_table.cpp
@@ -46,6 +46,11 @@ std::string ExportTable::getExphashSha256() const
 	return table ? table->getExphashSha256() : "";
 }
 
+std::string ExportTable::getDllName() const
+{
+	return table ? table->getDllName() : "";
+}
+
 /**
  * Get export name
  * @param position Index of selected export from table (indexed from 0)

--- a/src/fileinfo/file_information/file_information_types/export_table.h
+++ b/src/fileinfo/file_information/file_information_types/export_table.h
@@ -26,6 +26,7 @@ class ExportTable
 		std::string getExphashCrc32() const;
 		std::string getExphashMd5() const;
 		std::string getExphashSha256() const;
+		std::string getDllName() const;
 		std::string getExportName(std::size_t position) const;
 		std::string getExportAddressStr(std::size_t position, std::ios_base &(* format)(std::ios_base &)) const;
 		std::string getExportOrdinalNumberStr(std::size_t position, std::ios_base &(* format)(std::ios_base &)) const;

--- a/src/fileinfo/file_presentation/json_presentation.cpp
+++ b/src/fileinfo/file_presentation/json_presentation.cpp
@@ -1310,6 +1310,7 @@ bool JsonPresentation::present()
 	}
 
 	serializeString(writer, "inputFile", fileinfo.getPathToFile());
+	serializeString(writer, "dllName", fileinfo.getExportDllName());
 
 	presentErrors(writer);
 	presentLoaderError(writer);

--- a/src/fileinfo/file_presentation/plain_presentation.cpp
+++ b/src/fileinfo/file_presentation/plain_presentation.cpp
@@ -829,6 +829,13 @@ bool PlainPresentation::present()
 				<< utils::version::getVersionStringShort() << "\n";
 	}
 	Log::info() << "Input file               : " << fileinfo.getPathToFile() << "\n";
+
+	const std::string& dllName = fileinfo.getExportDllName();
+	if (!dllName.empty())
+	{
+		Log::info() << "Dll name                 : " << dllName << "\n";
+	}
+
 	presentSimple(BasicPlainGetter(fileinfo), false);
 	presentCompiler();
 	presentLanguages();


### PR DESCRIPTION
This PR adds `name` from the export directory table that represents the name of the DLL.