### PR TITLE
Change procedure linkage table indirect calls to direct calls

### DIFF
--- a/include/retdec/bin2llvmir/utils/ir_modifier.h
+++ b/include/retdec/bin2llvmir/utils/ir_modifier.h
@@ -51,6 +51,10 @@ class IrModifier
 				llvm::Type* ret,
 				llvm::ArrayRef<llvm::Value*> args);
 
+		static llvm::CallInst* modifyCallInstCallee(
+				llvm::CallInst* call,
+				llvm::Function* new_callee);
+
 		static void eraseUnusedInstructionRecursive(llvm::Value* insn);
 		static void eraseUnusedInstructionsRecursive(
 				std::unordered_set<llvm::Value*>& insns);

--- a/src/bin2llvmir/utils/ir_modifier.cpp
+++ b/src/bin2llvmir/utils/ir_modifier.cpp
@@ -1496,6 +1496,22 @@ llvm::CallInst* IrModifier::modifyCallInst(
 	return _modifyCallInst(call, conv, args);
 }
 
+/**
+ * Simply change callee of a call instruction.
+ *
+ * The call instruction is also given an empty
+ * parameter list, but at the point this method
+ * is called the call is not expected to have
+ * arguments yet.
+ */
+llvm::CallInst* IrModifier::modifyCallInstCallee(
+        llvm::CallInst* call,
+        llvm::Function* new_callee)
+{
+    llvm::ArrayRef<llvm::Value*> args;
+    return _modifyCallInst(call, new_callee, args);
+}
+
 void _eraseUnusedInstructionRecursive(
 		const std::unordered_set<llvm::Value*>& workset)
 {


### PR DESCRIPTION
When a function in an external dynamically-loaded library is
called, the call is made indirectly through the
procedure linkage table (PLT). The call into the PLT is
made with an ordinary call instruction, but in the PLT
there is a jump (not call) to the final destination.
In this situation retdec is not properly handling
the parameter passing. This change turns these indirect
calls into direct calls and deletes the PLT code.
This makes the result simpler and allows the parameters
to be properly passed.