### PR TITLE
Upgrade to Capstone release 4.0.2 with patch

### DIFF
--- a/cmake/deps.cmake
+++ b/cmake/deps.cmake
@@ -1,10 +1,11 @@
 
+# URL is for Capstone release 4.0.2.
 set(CAPSTONE_URL
-    "https://github.com/aquynh/capstone/archive/bc8a649b35188786754ea1b0bddd5cb48a039162.zip"
+    "https://github.com/capstone-engine/capstone/archive/1d230532840a37ac032c6ab80128238fc930c6c1.zip"
     CACHE STRING "URL of Capstone archive to use."
 )
 set(CAPSTONE_ARCHIVE_SHA256
-    "7d3075bce1f5622279c16a6f62fe8c548d4544bfc82292f6bf43907d0317fd10"
+    "659097fcda59ce927937f73dd87a4606de6e768b352045a077ed8d2165b7e935"
     CACHE STRING ""
 )
 

--- a/deps/capstone/patch.cmake
+++ b/deps/capstone/patch.cmake
@@ -11,9 +11,16 @@ string(REPLACE
     "${content}"
 )
 
-if("${new_content}" STREQUAL "${content}")
+string(REPLACE
+    "static void printS16ImmOperand(MCInst *MI, unsigned OpNo, SStream *O)\n{\n\tif (MCOperand_isImm(MCInst_getOperand(MI, OpNo))) {\n\t\tunsigned short Imm = (unsigned short)MCOperand_getImm(MCInst_getOperand(MI, OpNo));\n        if (Imm > HEX_THRESHOLD)\n            SStream_concat(O, \"0x%x\", Imm);\n        else\n            SStream_concat(O, \"%u\", Imm);\n"
+    "static void printS16ImmOperand(MCInst *MI, unsigned OpNo, SStream *O)\n{\n\tif (MCOperand_isImm(MCInst_getOperand(MI, OpNo))) {\n// RetDec fix\n\t\tshort Imm = (short)MCOperand_getImm(MCInst_getOperand(MI, OpNo));\n\t\tSStream_concat(O, \"%d\", Imm);\n"
+    new_content2
+    "${new_content}"
+)
+
+if("${new_content2}" STREQUAL "${content}")
     message(STATUS "-- Patching: ${full_path} skipped")
 else()
     message(STATUS "-- Patching: ${full_path} patched")
-    file(WRITE "${full_path}" "${new_content}")
+    file(WRITE "${full_path}" "${new_content2}")
 endif()

--- a/include/retdec/common/range.h
+++ b/include/retdec/common/range.h
@@ -27,7 +27,7 @@ public:
 
 	virtual const char* what() const noexcept override
 	{
-		return "Invalid Range: end is greater than start";
+		return "Invalid Range: start is greater than end";
 	}
 };
 

--- a/src/capstone2llvmir/powerpc/powerpc.cpp
+++ b/src/capstone2llvmir/powerpc/powerpc.cpp
@@ -2145,19 +2145,7 @@ void Capstone2LlvmIrTranslatorPowerpc_impl::translateB(cs_insn* i, cs_ppc* pi, l
 	uint32_t crReg = PPC_REG_CR0;
 	ppc_bc crBc = pi->bc;
 
-	// TODO: Special handling because of Capstone bug:
-	// https://github.com/aquynh/capstone/issues/968
-	if (i->id == PPC_INS_BDZLA)
-	{
-		if (pi->op_count != 1
-				|| pi->operands[0].type != PPC_OP_IMM)
-		{
-			throw GenericError("unhandled PPC_INS_BDZLA format");
-		}
-
-		target = llvm::ConstantInt::get(getDefaultType(), pi->operands[0].imm - i->address);
-	}
-	else if (toLR)
+	if (toLR)
 	{
 		target = loadRegister(PPC_REG_LR, irb);
 

--- a/src/capstone2llvmir/x86/x86_init.cpp
+++ b/src/capstone2llvmir/x86/x86_init.cpp
@@ -2113,6 +2113,8 @@ Capstone2LlvmIrTranslatorX86_impl::_i2fm =
 		{X86_INS_VCMPGE_OQPD, nullptr},
 		{X86_INS_VCMPGT_OQPD, nullptr},
 		{X86_INS_VCMPTRUE_USPD, nullptr},
+		{X86_INS_ENDBR32, &Capstone2LlvmIrTranslatorX86_impl::translateNop},
+		{X86_INS_ENDBR64, &Capstone2LlvmIrTranslatorX86_impl::translateNop},
 
 		{X86_INS_ENDING, nullptr}, // mark the end of the list of insn
 };

--- a/src/loader/loader/pe/pe_image.cpp
+++ b/src/loader/loader/pe/pe_image.cpp
@@ -109,7 +109,12 @@ Segment* PeImage::addSingleSegment(std::uint64_t address, std::vector<std::uint8
 
 bool PeImage::canAddSegment(std::uint64_t address, std::uint64_t memSize) const
 {
-	retdec::common::Range<std::uint64_t> newSegRange(address, memSize ? address + memSize : address + 1);
+	std::uint64_t end =  memSize ? address + memSize : address + 1;
+	// check for potential overflow - wrap around, memsize should be at most 32bit, so this could suffice
+	if (end < address)
+		end = std::numeric_limits<std::uint64_t>::max();
+
+	retdec::common::Range<std::uint64_t> newSegRange(address, end);
 	for (const auto& seg : getSegments())
 	{
 		auto overlapResult = OverlapResolver::resolve(retdec::common::Range<std::uint64_t>(seg->getAddress(), seg->getEndAddress()), newSegRange);


### PR DESCRIPTION
This is the latest released version of Capstone and the first Capstone release to support the endbr32 and endbr64 instructions. I was trying to add some new tests for RetDec, but although I can use an option to avoid producing the endbr instructions, the library has them so they end up in the produced binary. Thus if we want to add any new tests (which I do), we need to update to a newer Capstone.