### PR TITLE
Check for possible overflow when checking for segment overlap.

### DIFF
--- a/include/retdec/common/range.h
+++ b/include/retdec/common/range.h
@@ -27,7 +27,7 @@ public:
 
 	virtual const char* what() const noexcept override
 	{
-		return "Invalid Range: end is greater than start";
+		return "Invalid Range: start is greater than end";
 	}
 };
 

--- a/src/loader/loader/pe/pe_image.cpp
+++ b/src/loader/loader/pe/pe_image.cpp
@@ -109,7 +109,12 @@ Segment* PeImage::addSingleSegment(std::uint64_t address, std::vector<std::uint8
 
 bool PeImage::canAddSegment(std::uint64_t address, std::uint64_t memSize) const
 {
-	retdec::common::Range<std::uint64_t> newSegRange(address, memSize ? address + memSize : address + 1);
+	std::uint64_t end =  memSize ? address + memSize : address + 1;
+	// check for potential overflow - wrap around, memsize should be at most 32bit, so this could suffice
+	if (end < address)
+		end = std::numeric_limits<std::uint64_t>::max();
+
+	retdec::common::Range<std::uint64_t> newSegRange(address, end);
 	for (const auto& seg : getSegments())
 	{
 		auto overlapResult = OverlapResolver::resolve(retdec::common::Range<std::uint64_t>(seg->getAddress(), seg->getEndAddress()), newSegRange);


### PR DESCRIPTION
Image loader computes the end of the segment, which can overflow 64bit unsigned integer due to the large image base used. I've used simple detection that relies on segment size being limited to 32bit value, and if unsigned overflow happens, it overlaps, and `large 64bit  + max 32bit` will still be smaller than the `large 64bit`. If overflow is detected, I've clipped the end to the upper bound of the 64bit unsigned integer.