### PR TITLE
Add prototypes for dynamically-linked functions without headers

### DIFF
--- a/include/retdec/llvmir2hll/hll/hll_writer.h
+++ b/include/retdec/llvmir2hll/hll/hll_writer.h
@@ -91,6 +91,7 @@ protected:
 
 	virtual bool emitFunctionPrototypesHeader();
 	virtual bool emitFunctionPrototypes();
+	virtual bool emitFunctionPrototypes(const FuncSet &funcs);
 
 	virtual bool emitFunctionsHeader();
 	virtual bool emitFunctions();
@@ -99,7 +100,6 @@ protected:
 	virtual bool emitStaticallyLinkedFunctionsHeader();
 	virtual bool emitStaticallyLinkedFunctions();
 
-	virtual bool emitDynamicallyLinkedFunctionsHeader();
 	virtual bool emitDynamicallyLinkedFunctions();
 
 	virtual bool emitSyscallFunctionsHeader();


### PR DESCRIPTION
When the program involves dynamically-linked functions like _Znwj
(operator new) that return a pointer, it is necessary to have
prototypes for them, since otherwise they will be implicitly deduced
to return "int" which cannnot be dereferenced.

Previously RetDec was emitting comments telling which functions were
dynamically linked. This change moves them up before the functions are
emitted and instead emits prototypes for the functions. However,
RetDec also inserts includes of headers for functions with known
headers. So this change does not emit prototypes for functions with headers as that
would be redundant.  As a result, some dynamically-linked functions
that used to show in the comments no longer appear as the included
header will declare them.

The section header comment for dynamically-linked functions is only
produced if some prototypes are written for dynamically-linked
functions.

A related PR (https://github.com/avast/retdec-regression-tests/pull/121) 
adds tests as well as changes needed for existing tests.