### PR TITLE
Add printing of analysis time to retdec-fileinfo output

### DIFF
--- a/src/fileinfo/file_information/file_information.cpp
+++ b/src/fileinfo/file_information/file_information.cpp
@@ -106,6 +106,15 @@ std::string FileInformation::getPathToFile() const
 	return filePath;
 }
 
+/**
+ * Get time when the analysis was done
+ * @return Analysis time
+ */
+std::string FileInformation::getAnalysisTime() const
+{
+	return analysisTime;
+}
+
 std::string FileInformation::getTelfhash() const
 {
 	return telfhash;
@@ -3305,6 +3314,15 @@ void FileInformation::setStatus(ReturnCode state)
 void FileInformation::setPathToFile(const std::string &filepath)
 {
 	filePath = filepath;
+}
+
+/**
+ * Set when the analysis was done
+ * @param filepath Analysis time
+ */
+void FileInformation::setAnalysisTime(const std::string &analysistime)
+{
+	analysisTime = analysistime;
 }
 
 void FileInformation::setTelfhash(const std::string &hash)

--- a/src/fileinfo/file_information/file_information.h
+++ b/src/fileinfo/file_information/file_information.h
@@ -26,6 +26,7 @@ class FileInformation
 	private:
 		retdec::cpdetect::ReturnCode status = retdec::cpdetect::ReturnCode::OK;
 		std::string filePath;                          ///< path to input file
+		std::string analysisTime;                      ///< time when the analysis was done
 		std::string telfhash;                          ///< telfhash of ELF input file
 		std::string crc32;                             ///< CRC32 of input file
 		std::string md5;                               ///< MD5 of input file
@@ -78,6 +79,7 @@ class FileInformation
 		/// @{
 		retdec::cpdetect::ReturnCode getStatus() const;
 		std::string getPathToFile() const;
+		std::string getAnalysisTime() const;
 		std::string getTelfhash() const;
 		std::string getCrc32() const;
 		std::string getMd5() const;
@@ -504,6 +506,7 @@ class FileInformation
 		/// @{
 		void setStatus(retdec::cpdetect::ReturnCode state);
 		void setPathToFile(const std::string &filepath);
+		void setAnalysisTime(const std::string &analysistime);
 		void setTelfhash(const std::string &telfhash);
 		void setCrc32(const std::string &fileCrc32);
 		void setMd5(const std::string &fileMd5);

--- a/src/fileinfo/file_presentation/json_presentation.cpp
+++ b/src/fileinfo/file_presentation/json_presentation.cpp
@@ -97,9 +97,8 @@ bool presentSimple(
 /**
  * Constructor
  */
-JsonPresentation::JsonPresentation(FileInformation &fileinfo_, bool verbose_)
-		: FilePresentation(fileinfo_)
-		, verbose(verbose_)
+JsonPresentation::JsonPresentation(FileInformation &fileinfo_, bool verbose_, bool analysisTime_)
+		: FilePresentation(fileinfo_), verbose(verbose_), analysisTime(analysisTime_)
 {
 
 }
@@ -1320,6 +1319,11 @@ bool JsonPresentation::present()
 	if(verbose)
 	{
 		presentFileinfoVersion(writer);
+	}
+
+	if(analysisTime)
+	{
+		serializeString(writer, "analysisTime", fileinfo.getAnalysisTime());
 	}
 
 	serializeString(writer, "inputFile", fileinfo.getPathToFile());

--- a/src/fileinfo/file_presentation/json_presentation.h
+++ b/src/fileinfo/file_presentation/json_presentation.h
@@ -28,7 +28,8 @@ class JsonPresentation : public FilePresentation
 				rapidjson::ASCII<>>;
 
 	private:
-		bool verbose; ///< @c true - print all information about file
+		bool verbose;      ///< @c true - print all information about file
+		bool analysisTime; ///< @c true - print when the analysis was done
 
 		/// @name Auxiliary presentation methods
 		/// @{
@@ -63,7 +64,7 @@ class JsonPresentation : public FilePresentation
 				const IterativeSubtitleGetter &getter) const;
 		/// @}
 	public:
-		JsonPresentation(FileInformation &fileinfo_, bool verbose_);
+		JsonPresentation(FileInformation &fileinfo_, bool verbose_, bool analysisTime_);
 
 		virtual bool present() override;
 };

--- a/src/fileinfo/file_presentation/plain_presentation.cpp
+++ b/src/fileinfo/file_presentation/plain_presentation.cpp
@@ -348,8 +348,8 @@ void presentIterativeSimple(const IterativeSimpleGetter &getter)
 /**
  * Constructor
  */
-PlainPresentation::PlainPresentation(FileInformation &fileinfo_, bool verbose_, bool explanatory_) :
-	FilePresentation(fileinfo_), verbose(verbose_), explanatory(explanatory_)
+PlainPresentation::PlainPresentation(FileInformation &fileinfo_, bool verbose_, bool explanatory_, bool analysisTime_) :
+	FilePresentation(fileinfo_), verbose(verbose_), explanatory(explanatory_), analysisTime(analysisTime_)
 {
 
 }
@@ -827,6 +827,11 @@ bool PlainPresentation::present()
 	{
 		Log::info() << "RetDec Fileinfo version  : "
 				<< utils::version::getVersionStringShort() << "\n";
+	}
+	if(analysisTime)
+	{
+		Log::info() << "Analysis time            : "
+				<< fileinfo.getAnalysisTime() << "\n";
 	}
 	Log::info() << "Input file               : " << fileinfo.getPathToFile() << "\n";
 

--- a/src/fileinfo/file_presentation/plain_presentation.h
+++ b/src/fileinfo/file_presentation/plain_presentation.h
@@ -18,8 +18,9 @@ namespace fileinfo {
 class PlainPresentation : public FilePresentation
 {
 	private:
-		bool verbose;     ///< @c true - print all information about file
-		bool explanatory; ///< @c true - print explanatory notes
+		bool verbose;      ///< @c true - print all information about file
+		bool explanatory;  ///< @c true - print explanatory notes
+		bool analysisTime; ///< @c true - print when the analysis was done
 
 		/// @name Auxiliary presentation methods
 		/// @{
@@ -37,7 +38,7 @@ class PlainPresentation : public FilePresentation
 		void presentSignatures() const;
 		/// @}
 	public:
-		PlainPresentation(FileInformation &fileinfo_, bool verbose_, bool explanatory_);
+		PlainPresentation(FileInformation &fileinfo_, bool verbose_, bool explanatory_, bool analysisTime_);
 
 		virtual bool present() override;
 };


### PR DESCRIPTION
This adds printing of the time of an analysis into both plain and JSON output of `retdec-fileinfo`. It only does it when `--analysis-time` command line options is used if anyone ever relied on the fact that the output of `retdec-fileinfo` is always the same.