### PR TITLE
Added sanity check for page index when loading pages from broken samples

### DIFF
--- a/include/retdec/pelib/ImageLoader.h
+++ b/include/retdec/pelib/ImageLoader.h
@@ -53,7 +53,7 @@ enum struct PELIB_COMPARE_RESULT : std::uint32_t
 //-----------------------------------------------------------------------------
 // Windows build numbers
 
-const std::uint32_t	BuildNumberXP = 2600;           // Behavior equal to Windows XP
+const std::uint32_t BuildNumberXP = 2600;           // Behavior equal to Windows XP
 const std::uint32_t BuildNumberVista = 6000;        // Behavior equal to Windows Vista (SP0 = 6000, SP1 = 6001, SP2 = 6002)
 const std::uint32_t BuildNumber7 = 7600;            // Behavior equal to Windows 7 (SP0 = 7600, SP1 = 7601)
 const std::uint32_t BuildNumber8 = 9200;            // Behavior equal to Windows 8

--- a/src/pelib/ImageLoader.cpp
+++ b/src/pelib/ImageLoader.cpp
@@ -2549,7 +2549,7 @@ std::uint32_t PeLib::ImageLoader::captureImageSection(
 		if(pointerToRawData || isImageHeader)
 		{
 			// Fill all pages that contain data
-			while(pageOffset < sizeOfInitializedPages)
+			while(pageOffset < sizeOfInitializedPages && pageIndex < pages.size())
 			{
 				PELIB_FILE_PAGE & filePage = pages[pageIndex++];
 
@@ -2579,7 +2579,7 @@ std::uint32_t PeLib::ImageLoader::captureImageSection(
 		}
 
 		// Fill all pages that contain zeroed pages
-		while(pageOffset < sizeOfValidPages)
+		while(pageOffset < sizeOfValidPages && pageIndex < pages.size())
 		{
 			PELIB_FILE_PAGE & filePage = pages[pageIndex++];
 

--- a/src/pelib/ImageLoader.cpp
+++ b/src/pelib/ImageLoader.cpp
@@ -2253,7 +2253,7 @@ int PeLib::ImageLoader::captureImageSections(ByteBuffer & fileData, std::uint32_
 				// nor the end of the section must be beyond the end of the image
 				if(sectionEnd < sectionHeader.VirtualAddress || sectionEnd > sizeOfImage)
 				{
-					setLoaderError(LDR_ERROR_INVALID_SECTION_VA);
+					setLoaderError(LDR_ERROR_INVALID_SECTION_VSIZE);
 					break;
 				}
 			}


### PR DESCRIPTION
There are certain samples where page index might go beyond available pages when trying to load them which will be prevented with this patch.