### PR TITLE
Make YARA_MAKE_PROGRAM a FILEPATH (string) cache var

### DIFF
--- a/deps/yara/CMakeLists.txt
+++ b/deps/yara/CMakeLists.txt
@@ -10,7 +10,7 @@ endif()
 set(YARA_INCLUDE_DIR  ${YARA_DIR}/libyara/include)
 set(YARA_LIBRARY_NAME "libyara")
 
-option(YARA_MAKE_PROGRAM "A path to make tool which should be used to compile yara" "make")
+set(YARA_MAKE_PROGRAM "make" CACHE STRING "A path to make tool which should be used to compile yara")
 # Use the same make tool when using Unix makefiles
 if(${CMAKE_GENERATOR} STREQUAL "Unix Makefiles")
 	set(YARA_MAKE_PROGRAM ${CMAKE_MAKE_PROGRAM})


### PR DESCRIPTION
option() is intended for boolean variables only. This could break the build e.g. with cmake 3.23.4 on macOS where the passed default "make" was interpreted as false and "OFF" was instead passed to the yara configure.
The correct way is to use an explicit CACHE variable here.

![Bildschirm­foto 2022-12-08 um 20 02 09](https://user-images.githubusercontent.com/1460997/206544296-459b9944-8aef-409b-890e-05b6af812e1a.png)