### PR TITLE
Do not transform TLSH and provide it as-is (uppercase)

### DIFF
--- a/src/fileformat/file_format/elf/elf_format.cpp
+++ b/src/fileformat/file_format/elf/elf_format.cpp
@@ -1902,7 +1902,7 @@ void ElfFormat::loadTelfhash()
 
 		tlsh.final();
 		const int show_version = 1; /* this prepends the hash with 'T' + number of the version */
-		telfhash = toLower(tlsh.getHash(show_version));
+		telfhash = tlsh.getHash(show_version);
 	}
 }
 

--- a/src/fileformat/types/import_table/elf_import_table.cpp
+++ b/src/fileformat/types/import_table/elf_import_table.cpp
@@ -49,7 +49,7 @@ void ElfImportTable::computeHashes()
 		tlsh.final();
 		/* this prepends the hash with 'T' + number of the version */
 		const int show_version = 1;
-		impHashTlsh = toLower(tlsh.getHash(show_version));
+		impHashTlsh = tlsh.getHash(show_version);
 
 		impHashCrc32 = getCrc32(data, impHashString.size());
 		impHashMd5 = getMd5(data, impHashString.size());

--- a/src/fileformat/types/import_table/import_table.cpp
+++ b/src/fileformat/types/import_table/import_table.cpp
@@ -284,7 +284,7 @@ void ImportTable::computeHashes()
 		tlsh.final();
 		/* this prepends the hash with 'T' + number of the version */
 		const int show_version = 1;
-		impHashTlsh = toLower(tlsh.getHash(show_version));
+		impHashTlsh = tlsh.getHash(show_version);
 
 		impHashCrc32 = getCrc32(data, impHashBytes.size());
 		impHashMd5 = getMd5(data, impHashBytes.size());


### PR DESCRIPTION
These kind of hashes are always provided as upper-case (for example on VirusTotal). We are the only one providing them in lower-case and we are doing it deliberately. I suggest not to do it and provide them as-is and that is uppercase.