### PR TITLE
Fix .NET parser trying to read strings from String stream when out-of-bounds of the file

### DIFF
--- a/.github/workflows/macOS/install-deps.sh
+++ b/.github/workflows/macOS/install-deps.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/bash
 
-brew install pkg-config autoconf automake libtool openssl python@3.7
-brew link --overwrite python@3.7
+brew install pkg-config autoconf automake libtool openssl python@3.10
+brew link --overwrite python@3.10

--- a/.github/workflows/retdec-ci.yml
+++ b/.github/workflows/retdec-ci.yml
@@ -110,7 +110,7 @@ jobs:
 
   docs-build:
     name: doxygen-build (Linux)
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     steps:
       # Checkouts the correct commit/branch.

--- a/src/fileformat/file_format/pe/pe_format.cpp
+++ b/src/fileformat/file_format/pe/pe_format.cpp
@@ -2593,6 +2593,13 @@ void PeFormat::parseStringStream(std::uint64_t baseAddress, std::uint64_t offset
 	while (currentOffset < size)
 	{
 		std::string string;
+		std::uint64_t c = 0;
+		auto successful_read = get1Byte(address + currentOffset, c, getEndianness());
+		// If the reading fails (OOB or other) don't continue and terminate
+		if (!successful_read)
+		{
+			break;
+		}
 		getNTBS(address + currentOffset, string);
 		stringStream->addString(currentOffset, string);
 		// +1 for null-terminator


### PR DESCRIPTION
When reading  strings from String stream of .NET binaries, there was no check, if the reading was actually succesfull (there is something to read in the file on that offset).

The string parsing is set to stop when it fails to read some string as they are read consecutively, so if offset X is out of bounds, X+1 should be too and there should be no reason to read further.