### PR TITLE
MacOS workflow fix - Use new version of python and ubuntu that is not deprecated

### DIFF
--- a/.github/workflows/macOS/install-deps.sh
+++ b/.github/workflows/macOS/install-deps.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/bash
 
-brew install pkg-config autoconf automake libtool openssl python@3.7
-brew link --overwrite python@3.7
+brew install pkg-config autoconf automake libtool openssl python@3.10
+brew link --overwrite python@3.10

--- a/.github/workflows/retdec-ci.yml
+++ b/.github/workflows/retdec-ci.yml
@@ -110,7 +110,7 @@ jobs:
 
   docs-build:
     name: doxygen-build (Linux)
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     steps:
       # Checkouts the correct commit/branch.


### PR DESCRIPTION
MacOS CI workflow is failing because python3.7 is deprecated and the build fails.

The doxygen build also fails due to deprecated github CI ubuntu version, it was changed to ubuntu-latest so it won't happen again.