### PR TITLE
Use isDotnet check before parsing binary as .NET

### DIFF
--- a/src/fileformat/file_format/pe/pe_format.cpp
+++ b/src/fileformat/file_format/pe/pe_format.cpp
@@ -2160,6 +2160,10 @@ void PeFormat::loadDotnetHeaders()
 	metadataHeader->setVersion(version);
 	metadataHeader->setFlags(flags);
 
+	// Check if it is actually a .NET application, this check is important to be aligned with YARA scanning
+	if (!this->isDotNet())
+		return;
+
 	auto currentAddress = metadataHeaderStreamsHeader + 4;
 	for (std::uint64_t i = 0; i < streamCount; ++i)
 	{

--- a/src/fileformat/file_format/pe/pe_format.cpp
+++ b/src/fileformat/file_format/pe/pe_format.cpp
@@ -2161,7 +2161,7 @@ void PeFormat::loadDotnetHeaders()
 	metadataHeader->setFlags(flags);
 
 	// Check if it is actually a .NET application, this check is important to be aligned with YARA scanning
-	if (!this->isDotNet())
+	if (!isDotNet())
 		return;
 
 	auto currentAddress = metadataHeaderStreamsHeader + 4;


### PR DESCRIPTION
To unify .NET parsing in YARA and Retdec, the same kind of check has to be used before trying to parse binary as .NET (to avoid malformed binaries). The checking logic was already implemented by me a year ago, but it was for some reason used only in compiler detection heuristics and not during .NET parsing.