### PR TITLE
Ignore self-references when reconstructing full names of nested classes

### DIFF
--- a/src/fileformat/types/dotnet_types/dotnet_type_reconstructor.cpp
+++ b/src/fileformat/types/dotnet_types/dotnet_type_reconstructor.cpp
@@ -666,6 +666,10 @@ bool DotnetTypeReconstructor::reconstructNestedClasses()
 		if (enclosingItr == defClassTable.end())
 			continue;
 
+		// Ignore self-references
+		if (nestedItr == enclosingItr)
+			continue;
+
 		const std::string& namespac = nestedItr->second->getNameSpace();
 		if (namespac.empty())
 		{


### PR DESCRIPTION
Self-references in the .NET NestedClass table should be ignored as they are not allowed by .NET ECMA.