### PR TITLE
Fix warnings in `make doc`

### DIFF
--- a/src/bin2llvmir/optimizations/decoder/decoder_init.cpp
+++ b/src/bin2llvmir/optimizations/decoder/decoder_init.cpp
@@ -21,7 +21,6 @@ namespace bin2llvmir {
 /**
  * Initialize capstone2llvmir translator according to the architecture of
  * file to decompile.
- * @return @c True if error, @c false otherwise.
  */
 void Decoder::initTranslator()
 {

--- a/src/bin2llvmir/optimizations/idioms/idioms_abstract.cpp
+++ b/src/bin2llvmir/optimizations/idioms/idioms_abstract.cpp
@@ -44,7 +44,6 @@ bool IdiomsAbstract::findBranchDependingOn(llvm::BranchInst ** br, llvm::BasicBl
  *
  * @param val instruction value to look for
  * @param bb BasicBlock to erase instruction from
- * @return void
  */
 void IdiomsAbstract::eraseInstFromBasicBlock(llvm::Value * val, llvm::BasicBlock * bb) {
 	for (llvm::BasicBlock::iterator end = bb->end(), i = bb->begin(); i != end; ++i) {

--- a/src/config/parameters.cpp
+++ b/src/config/parameters.cpp
@@ -476,7 +476,6 @@ void Parameters::fixRelativePaths(const std::string& configPath)
 
 /**
  * Returns JSON object (associative array) holding parameters information.
- * @return JSON object.
  */
 template <typename Writer>
 void Parameters::serialize(Writer& writer) const

--- a/src/cpdetect/heuristics/heuristics.cpp
+++ b/src/cpdetect/heuristics/heuristics.cpp
@@ -585,8 +585,6 @@ bool Heuristics::parseOpen64Comment(const std::string &record)
 
 /**
  * Try to detect used compiler based on content of comment sections
- * @return @c true if used compiler was successfully detected,
- *         @c false otherwise
  */
 void Heuristics::getCommentSectionsHeuristics()
 {

--- a/src/fileinfo/file_information/file_information.cpp
+++ b/src/fileinfo/file_information/file_information.cpp
@@ -1342,7 +1342,6 @@ std::string FileInformation::getDepsListFailedToLoad() const
 
 /**
  * Sets the name of the dependency file that failed to load
- * @return Nothing
  */
 void FileInformation::setDepsListFailedToLoad(const std::string & depsList)
 {


### PR DESCRIPTION
Remove empty return types from doxygen comments to fix warnings.


This will be fix below warnings and make GitHub Actions doc test pass.

```
$ cat build/doc/doxygen/doxygen.log
/Users/takano32/GitHub/retdec/src/bin2llvmir/optimizations/decoder/decoder_init.cpp:22: warning: found documented return type for retdec::bin2llvmir::Decoder::initTranslator that does not return anything
/Users/takano32/GitHub/retdec/src/bin2llvmir/optimizations/idioms/idioms_abstract.cpp:43: warning: found documented return type for retdec::bin2llvmir::IdiomsAbstract::eraseInstFromBasicBlock that does not return anything
/Users/takano32/GitHub/retdec/src/config/parameters.cpp:478: warning: found documented return type for retdec::config::Parameters::serialize that does not return anything
/Users/takano32/GitHub/retdec/src/cpdetect/heuristics/heuristics.cpp:587: warning: found documented return type for retdec::cpdetect::Heuristics::getCommentSectionsHeuristics that does not return anything
/Users/takano32/GitHub/retdec/src/fileinfo/file_information/file_information.cpp:1344: warning: found documented return type for retdec::fileinfo::FileInformation::setDepsListFailedToLoad that does not return anything
```


https://github.com/takano32/retdec/actions/runs/5783455011