### PR TITLE
LLVM Error objects actually need to be consumed before their destruction

### DIFF
--- a/src/fileformat/file_format/macho/macho_format.cpp
+++ b/src/fileformat/file_format/macho/macho_format.cpp
@@ -980,6 +980,7 @@ void MachOFormat::dyldInfoCommand(const llvm::object::MachOObjectFile::LoadComma
 		if (err)
 		{
 			// ignore errors
+			consumeError(std::move(err));
 		}
 	}
 
@@ -1005,6 +1006,7 @@ void MachOFormat::dyldInfoCommand(const llvm::object::MachOObjectFile::LoadComma
 		if (err)
 		{
 			// ignore errors
+			consumeError(std::move(err));
 		}
 	}
 
@@ -1024,6 +1026,7 @@ void MachOFormat::dyldInfoCommand(const llvm::object::MachOObjectFile::LoadComma
 		if (err)
 		{
 			// ignore errors
+			consumeError(std::move(err));
 		}
 	}
 
@@ -1043,6 +1046,7 @@ void MachOFormat::dyldInfoCommand(const llvm::object::MachOObjectFile::LoadComma
 		if (err)
 		{
 			// ignore errors
+			consumeError(std::move(err));
 		}
 	}
 }


### PR DESCRIPTION
I'm not sure how we haven't encountered this before but we actually need to consume errors to ignore them completely. Otherwise, they abort the program.