### PR TITLE
Ignore `doxygen` warning log

### DIFF
--- a/.github/workflows/retdec-ci.yml
+++ b/.github/workflows/retdec-ci.yml
@@ -127,17 +127,3 @@ jobs:
           cmake .. -DCMAKE_INSTALL_PREFIX=install -DRETDEC_DOC=ON
           make doc -j$(nproc)
 
-      - name: Test Docs
-        run: |
-          file="build/doc/doxygen/doxygen.log"
-          echo "checking file: $file"
-          content="$(cat $file)"
-          if [ "$content" = "" ]; then
-            echo "===> ok"
-            else
-            echo "===> fail:"
-            echo "=========================================="
-            echo "$content"
-            echo "=========================================="
-            exit 1
-          fi


### PR DESCRIPTION
Document generated successfly if `make doc` exit code equals `0`.

So, ignoring warnigs is reasonable in GitHub Actions, I think.
