### PR TITLE
[GitHub Actions] ignore doxygen wranings

### DIFF
--- a/.github/workflows/retdec-ci.yml
+++ b/.github/workflows/retdec-ci.yml
@@ -127,7 +127,7 @@ jobs:
           cmake .. -DCMAKE_INSTALL_PREFIX=install -DRETDEC_DOC=ON
           make doc -j$(nproc)
 
-      - name: Test Docs
+      - name: Display Docs Warnings
         run: |
           file="build/doc/doxygen/doxygen.log"
           echo "checking file: $file"
@@ -139,5 +139,5 @@ jobs:
             echo "=========================================="
             echo "$content"
             echo "=========================================="
-            exit 1
+            exit 0
           fi


### PR DESCRIPTION
Document generated successfly if `make doc` exit code equals `0`.

So, ignoring warnigs is reasonable in GitHub Actions, I think.
