### PR TITLE
fix get10Byte on platforms where long double is >80 bits.

### DIFF
--- a/src/utils/byte_value_storage.cpp
+++ b/src/utils/byte_value_storage.cpp
@@ -1019,7 +1019,12 @@ bool ByteValueStorage::get10ByteImpl(
 	{
 		std::vector<std::uint8_t> d8;
 		double10ToDouble8(d8, data);
-		memcpy(&res, d8.data(), d8.size());
+
+		double d8res = 0;
+		static_assert(sizeof(double) == 8);
+
+		memcpy(&d8res, d8.data(), d8.size());
+		res = d8res;
 	}
 
 	return true;

--- a/src/utils/system.cpp
+++ b/src/utils/system.cpp
@@ -7,6 +7,8 @@
 #include "retdec/utils/os.h"
 #include "retdec/utils/system.h"
 
+#include <cfloat>
+
 namespace retdec {
 namespace utils {
 
@@ -22,11 +24,11 @@ bool isLittleEndian() {
 }
 
 /**
-* @brief Finds out if the runtime system supports <tt>long double</tt> (at least
-*        10 bytes long).
+* @brief Finds out if the runtime system supports 80-bit <tt>long double</tt>
+*        (exactly 10 bytes long).
 */
 bool systemHasLongDouble() {
-	return sizeof(long double) >= 10;
+	return sizeof(long double) >= 10 && (LDBL_MANT_DIG == 64);
 }
 
 } // namespace utils


### PR DESCRIPTION
For platforms such as aarch64 with a non 80-bit "long double" type, the tests fail since they assume an 80-bit long double type. 

```
retdec-tests-utils
/build/source/tests/utils/byte_value_storage_tests.cpp:357: Failure
Expected equality of these values:
  0.31348419189453125
  val
    Which is: 0
```

Specifically, the tests construct a long double with the byte pattern: `00000000000081a0fd3f000000000000`. When interpreted as:
- a float 80, this is 0.31348419189453125 as expected,
- a float 128, this is 1.95671814821071780e-4942 which fails the test and displays as zero.

We fix this by restricting systemHasLongDouble to return true only when the platform has 80-bit long double (detected by 64-bit mantissa). Then, we change the fallback get10ByteImpl to construct a correct long double by using the language's builtin float handling, instead of naively copying

This handles both where long double is smaller and greater than 80 bits, though the trip through double does limit maximum precision. Given the fallback already assumes 64-bits is acceptable, I don't think this is a big problem.

If more precision is desired, it is not too hard to write a float10 to float16 method. I found the code in the linked perl blog didn't seem to be correct, but it is possible with not too much difficulty.

