### PR TITLE
Debug ARM64

### DIFF
--- a/src/bin2llvmir/providers/abi/arm64.cpp
+++ b/src/bin2llvmir/providers/abi/arm64.cpp
@@ -35,7 +35,7 @@ AbiArm64::AbiArm64(llvm::Module* m, Config* c) :
 bool AbiArm64::isGeneralPurposeRegister(const llvm::Value* val) const
 {
 	uint32_t rid = getRegisterId(val);
-	return ARM64_REG_X0 <= rid && rid <= ARM64_REG_X30;
+	return (ARM64_REG_X0 <= rid && rid <= ARM64_REG_X28)||rid==ARM64_REG_X29||rid==ARM64_REG_X30;
 }
 
 bool AbiArm64::isNopInstruction(cs_insn* insn)


### PR DESCRIPTION
I have fixed a bug in the ARM64 code where, due to a misunderstanding by the programmer regarding the value of REGx29 and REGx30, the function isGeneralPurposeRegister was incorrectly always returning false. This issue led to frequent erroneous decompilations by RetDec.

Additionally, I have utilized an iterative approach to identify parameters within functions that were previously obscured because they were passed as arguments to called functions. This enhancement enables more accurate parameter recognition, thus optimizing RetDec's performance.