### PR TITLE
Get config stack var after node simplification

### DIFF
--- a/src/bin2llvmir/optimizations/stack/stack.cpp
+++ b/src/bin2llvmir/optimizations/stack/stack.cpp
@@ -158,21 +158,11 @@ void StackAnalysis::handleInstruction(
 		}
 	}
 
-	auto* debugSv = getDebugStackVariable(inst->getFunction(), root);
-	auto* configSv = getConfigStackVariable(inst->getFunction(), root);
-
 	root.simplifyNode();
 	LOG << root << std::endl;
 
-	if (debugSv == nullptr)
-	{
-		debugSv = getDebugStackVariable(inst->getFunction(), root);
-	}
-
-	if (configSv == nullptr)
-	{
-		configSv = getConfigStackVariable(inst->getFunction(), root);
-	}
+	auto* debugSv = getDebugStackVariable(inst->getFunction(), root);
+	auto* configSv = getConfigStackVariable(inst->getFunction(), root);
 
 	auto* ci = dyn_cast_or_null<ConstantInt>(root.value);
 	if (ci == nullptr)


### PR DESCRIPTION
It doesn't make sense to get config stack variables before node simplification, because the stack offset obtained from the node can change* after simplification, perhaps through arithmetic evaluation. This pr makes it so that debug and config stack variables are only obtained after node simplification.

*Confirmed via tracing.