### PR TITLE
capstone2llvmir/arm64: handle ARM64_VAS_2D vector arrangement

### DIFF
--- a/src/capstone2llvmir/arm64/arm64.cpp
+++ b/src/capstone2llvmir/arm64/arm64.cpp
@@ -398,6 +398,7 @@ llvm::Value* Capstone2LlvmIrTranslatorArm64_impl::extractVectorValue(
 			val = irb.CreateLShr(val, llvm::ConstantInt::get(val->getType(), 32 * op.vector_index));
 			val = irb.CreateZExtOrTrunc(val, llvm::IntegerType::getInt32Ty(_module->getContext()));
 			return irb.CreateBitCast(val, llvm::Type::getFloatTy(_module->getContext()));
+		case ARM64_VAS_2D:
 		case ARM64_VAS_1D:
 			val = irb.CreateLShr(val, llvm::ConstantInt::get(val->getType(), 64 * op.vector_index));
 			val = irb.CreateZExtOrTrunc(val, llvm::IntegerType::getInt64Ty(_module->getContext()));

--- a/tests/capstone2llvmir/arm64_tests.cpp
+++ b/tests/capstone2llvmir/arm64_tests.cpp
@@ -8246,6 +8246,24 @@ TEST_P(Capstone2LlvmIrTranslatorArm64Tests, ARM64_INS_FSQRT_d_d)
 }
 */
 
+// https://github.com/avast/retdec/issues/1225
+TEST_P(Capstone2LlvmIrTranslatorArm64Tests, issue_1225_vas_2d_is_not_unknown_vess_type)
+{
+	setRegisters({
+		{ARM64_REG_V1, 0x1234},
+		{ARM64_REG_V2, 0x5678},
+	});
+
+	emulate("add v0.2d, v1.2d, v2.2d");
+
+	EXPECT_JUST_REGISTERS_LOADED({ARM64_REG_V1, ARM64_REG_V2});
+	EXPECT_JUST_REGISTERS_STORED({
+		{ARM64_REG_V0, ANY},
+	});
+	EXPECT_NO_MEMORY_LOADED_STORED();
+	EXPECT_NO_VALUE_CALLED();
+}
+
 // https://github.com/avast/retdec/issues/998
 TEST_P(Capstone2LlvmIrTranslatorArm64Tests, issue_998)
 {


### PR DESCRIPTION
Fixes #1225.

## Problem

`Capstone2LlvmIrTranslatorArm64_impl::extractVectorValue()` switches on `op.vas` and handles every Capstone v5 VESS arrangement (`16B/8B/4B/1B`, `8H/4H/2H/1H`, `4S/2S/1S`, `1D`, `1Q`, `INVALID`) **except `ARM64_VAS_2D`**, which falls into the `default:` branch and throws `GenericError("Arm64: extractVectorValue(): Unknown VESS type")`.

`extractVectorValue()` is invoked from `loadOp()` for every vector register operand, and the exception is caught by `Decoder::runCatcher()`, which logs the error and calls `exit(1)`. So decompiling any AArch64 binary that contains a `.2d`-arranged SIMD operand — e.g. `add v0.2d, v1.2d, v2.2d`, which compilers emit routinely (inlined `memcpy`/`memset`, vectorized FP loops) — aborts the entire decompilation. This is the exact failure reported in #1225.

## Fix

Treat `2D` like the existing `1D` case (64-bit elements), the same way the other multi-element arrangements (`16B`/`8H`/`4S`) already share their element-size branch with their single-element forms. One added line.

## Testing

* Added a regression test (`add v0.2d, v1.2d, v2.2d`). Without the fix it fails with the `Unknown VESS type` error from the issue; with the fix it passes.
* Full `retdec-tests-capstone2llvmir` suite passes (3927 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014nNMVbAuffaPPQuYdLZgD1