### PR TITLE
capstone2llvmir/x86: fix AF computation for SBB

### DIFF
--- a/src/capstone2llvmir/capstone2llvmir_impl.cpp
+++ b/src/capstone2llvmir/capstone2llvmir_impl.cpp
@@ -1512,8 +1512,8 @@ llvm::Value* Capstone2LlvmIrTranslator_impl<CInsn, CInsnOp>::generateBorrowSubCI
 		cf = loadRegister(getCarryRegister(), irb);
 	}
 	auto* cfc = irb.CreateZExtOrTrunc(cf, sub->getType());
-	auto* add = irb.CreateAdd(sub, cfc);
-	return irb.CreateICmpUGT(add, ci15);
+	auto* res = irb.CreateSub(sub, cfc);
+	return irb.CreateICmpUGT(res, ci15);
 }
 
 //

--- a/src/capstone2llvmir/x86/x86.cpp
+++ b/src/capstone2llvmir/x86/x86.cpp
@@ -3134,10 +3134,11 @@ void Capstone2LlvmIrTranslatorX86_impl::translateSbb(cs_insn* i, cs_x86* xi, llv
 	std::tie(op0, op1) = loadOpBinary(xi, irb, eOpConv::SEXT_TRUNC_OR_BITCAST);
 	auto* cf = loadRegister(X86_REG_CF, irb, op0->getType(), eOpConv::ZEXT_TRUNC_OR_BITCAST);
 
+	auto* af = generateBorrowSubCInt4(op0, op1, irb, cf);
 	op1 = irb.CreateAdd(op1, cf);
 	auto* sub = irb.CreateSub(op0, op1);
 	storeRegistersPlusSflags(irb, sub, {
-			{X86_REG_AF, generateBorrowSubCInt4(op0, op1, irb)},
+			{X86_REG_AF, af},
 			{X86_REG_CF, generateBorrowSubC(sub, op0, op1, irb)},
 			{X86_REG_OF, generateOverflowSubC(sub, op0, op1, irb)}});
 

--- a/tests/capstone2llvmir/x86_tests.cpp
+++ b/tests/capstone2llvmir/x86_tests.cpp
@@ -4507,7 +4507,7 @@ TEST_P(Capstone2LlvmIrTranslatorX86Tests, X86_INS_SBB_cf_false)
 		{X86_REG_ZF, ANY},
 		{X86_REG_SF, ANY},
 		{X86_REG_PF, ANY},
-		{X86_REG_AF, ANY},
+		{X86_REG_AF, true}, // 0x4 < 0x7 + 0 => borrow from bit 3
 	});
 	EXPECT_NO_MEMORY_LOADED_STORED();
 	EXPECT_NO_VALUE_CALLED();
@@ -4533,7 +4533,7 @@ TEST_P(Capstone2LlvmIrTranslatorX86Tests, X86_INS_SBB_cf_true)
 		{X86_REG_ZF, ANY},
 		{X86_REG_SF, ANY},
 		{X86_REG_PF, ANY},
-		{X86_REG_AF, ANY},
+		{X86_REG_AF, true}, // 0x4 < 0x7 + 1 => borrow from bit 3
 	});
 	EXPECT_NO_MEMORY_LOADED_STORED();
 	EXPECT_NO_VALUE_CALLED();
@@ -4558,7 +4558,7 @@ TEST_P(Capstone2LlvmIrTranslatorX86Tests, X86_INS_SBB_eax_eax_cf_false)
 		{X86_REG_ZF, ANY},
 		{X86_REG_SF, ANY},
 		{X86_REG_PF, ANY},
-		{X86_REG_AF, ANY},
+		{X86_REG_AF, false}, // 0x4 < 0x4 + 0 is false => no borrow
 	});
 	EXPECT_NO_MEMORY_LOADED_STORED();
 	EXPECT_NO_VALUE_CALLED();
@@ -4583,7 +4583,7 @@ TEST_P(Capstone2LlvmIrTranslatorX86Tests, X86_INS_SBB_eax_eax_cf_true)
 		{X86_REG_ZF, ANY},
 		{X86_REG_SF, ANY},
 		{X86_REG_PF, ANY},
-		{X86_REG_AF, ANY},
+		{X86_REG_AF, true}, // 0x4 < 0x4 + 1 => borrow from bit 3
 	});
 	EXPECT_NO_MEMORY_LOADED_STORED();
 	EXPECT_NO_VALUE_CALLED();


### PR DESCRIPTION
Fixes #1196.

## Problem

Two defects combined to make the auxiliary-carry flag wrong after `SBB`:

1. `translateSbb()` executes `op1 = irb.CreateAdd(op1, cf);` **before** calling `generateBorrowSubCInt4(op0, op1, irb)`, so AF is computed from `op1 + CF` instead of the original `op1`.
2. `generateBorrowSubCInt4()` then loads CF again and **adds** it to the nibble difference (`(op0 & 15) - (op1 & 15) + CF`), while the x86 nibble-borrow condition requires it to be **subtracted**.

The net effect matches the reproducer in #1196: for `sbb eax, eax` with CF=1, RetDec sets AF only when the low nibble of `eax` is `0xF`, whereas a real CPU always sets AF in that case (the emitted IR quoted in the issue is byte-for-byte what master generates today).

## Fix

Compute AF from the original operands with CF passed explicitly (the helper already had an optional `cf` parameter), and change the helper to subtract CF:

```
AF = ((op0 & 15) - (op1 & 15) - CF) u> 15
```

This mirrors how `translateAdc()` uses `generateCarryAddCInt4(op0, op1, irb, cf)`. `generateBorrowSubCInt4()` has no other call site, so nothing else is affected; the CF/OF computations for SBB are intentionally left untouched.

Correctness argument: `(op0 & 15) - (op1 & 15) - CF` lies in `[-16, 15]`; negative values wrap above 15 for any operand width ≥ 5 bits, so `u> 15` is exactly "borrow out of bit 3". Brute-forcing all 512 `(op0 nibble, op1 nibble, CF)` combinations: master computes AF wrong in 30 cases (all with CF=1); the fixed formula matches the hardware definition in all cases.

## Testing

* The four existing SBB tests asserted `{X86_REG_AF, ANY}`; they now assert the real CPU values. The `sbb eax, eax` / CF=1 case fails without the fix and passes with it.
* Full `retdec-tests-capstone2llvmir` suite passes (3927 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014nNMVbAuffaPPQuYdLZgD1