### PR TITLE
demanglertool: fix "succeded" typo in help text

### DIFF
--- a/src/demanglertool/demangler.cpp
+++ b/src/demanglertool/demangler.cpp
@@ -27,7 +27,7 @@ const std::string helpmsg =
 	"Usage:\n"
 	"\tretdec-demangler [-h, --help]   | Show this help.\n"
 	"\tretdec-demangler --version      | Show RetDec version.\n"
-	"\tretdec-demangler <mangledname>  | Attempt to demangle <mangledname> using all available demanglers and print result if succeded.\n";
+	"\tretdec-demangler <mangledname>  | Attempt to demangle <mangledname> using all available demanglers and print result if succeeded.\n";
 
 /**
  * @brief Main function of the Demangler tool.


### PR DESCRIPTION
One-character fix in the `retdec-demangler` usage text: "succeded" → "succeeded".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014nNMVbAuffaPPQuYdLZgD1