### PR TITLE
Fix "catched" -> "caught" in user-visible messages

### DIFF
--- a/src/bin2llvmir/providers/fileimage.cpp
+++ b/src/bin2llvmir/providers/fileimage.cpp
@@ -418,9 +418,9 @@ llvm::Constant* FileImage::getConstant(
 	}
 	else
 	{
-		errs() << "unhandled type catched : "
+		errs() << "unhandled type caught : "
 				<< *type << " @ " << addr.toHexString() << "\n";
-		assert(false && "unhandled type catched");
+		assert(false && "unhandled type caught");
 		return nullptr;
 	}
 

--- a/src/retdec-decompiler/retdec-decompiler.cpp
+++ b/src/retdec-decompiler/retdec-decompiler.cpp
@@ -1061,7 +1061,7 @@ int main(int argc, char **argv)
 	}
 	catch (const std::bad_alloc& e)
 	{
-		Log::error() << "catched std::bad_alloc" << std::endl;
+		Log::error() << "caught std::bad_alloc" << std::endl;
 		ret = EXIT_BAD_ALLOC;
 	}
 


### PR DESCRIPTION
- `retdec-decompiler` error output on `std::bad_alloc` — the message users see and report (it is, for example, the title of #1216)
- bin2llvmir fileimage stderr message and its assert

String literals only; no test references these messages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014nNMVbAuffaPPQuYdLZgD1