### PR TITLE
scripts: fix macOS detection in retdec-utils.py

### DIFF
--- a/scripts/retdec-utils.py
+++ b/scripts/retdec-utils.py
@@ -23,7 +23,7 @@ SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 AR = os.path.join(SCRIPT_DIR, 'retdec-ar-extractor')
 EXTRACT = os.path.join(SCRIPT_DIR, 'retdec-macho-extractor')
 
-if platform == "darwin":
+if sys.platform == "darwin":
     # mac os x need the `gnu-time´ package
     LOG_TIME = ['/usr/local/bin/gtime', '-v']
 else:


### PR DESCRIPTION
`retdec-utils.py` compares the imported `platform` **module object** to the string `"darwin"`:

```python
if platform == "darwin":
```

This is always `False`, so the `gtime` path is never selected on macOS and memory tracking there tries `/usr/bin/time -v`, which BSD time does not support. Compare `sys.platform` instead.

Verified on Linux that the module imports cleanly and still selects `['/usr/bin/time', '-v']`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014nNMVbAuffaPPQuYdLZgD1