### PR TITLE
scripts: fix outdated install hint in retdec-utils.py

### DIFF
--- a/scripts/retdec-utils.py
+++ b/scripts/retdec-utils.py
@@ -307,9 +307,9 @@ def ensure_script_is_being_run_from_installed_retdec():
     # See https://github.com/avast/retdec/issues/418
     if not os.path.dirname(__file__).endswith('bin'):
         print_error_and_die(
-            'You need to build and install RetDec first and then run the installed script via '
-            '`python $RETDEC_INSTALL_DIR/bin/retdec-decompiler.py`.\n'
-            'For more details, see https://github.com/avast/retdec#installation-and-use'
+            'You need to build and install RetDec first and then run the installed script '
+            'from `$RETDEC_INSTALL_DIR/bin`.\n'
+            'For more details, see https://github.com/avast/retdec#installation'
         )
 
 


### PR DESCRIPTION
The error shown when a script is run from the source tree tells users to run `python $RETDEC_INSTALL_DIR/bin/retdec-decompiler.py` — but that script was removed in v5.0 (`retdec-decompiler` is a native binary now), and the function is actually used by the remaining Python scripts (`retdec-fileinfo.py`, `retdec-unpacker.py`, …), not the decompiler. The linked `#installation-and-use` anchor also no longer exists (the README sections are now *Installation* and *Use*).

Point users at the installed script in `$RETDEC_INSTALL_DIR/bin` and at the `#installation` section instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014nNMVbAuffaPPQuYdLZgD1