### PR TITLE
support: use the 'data' tar extraction filter in install-share.py

### DIFF
--- a/support/install-share.py
+++ b/support/install-share.py
@@ -76,7 +76,10 @@ def main():
     print('Unpacking archive ...')
     with tarfile.open(arch_path) as tar:
         try:
-            tar.extractall(support_dir)
+            if hasattr(tarfile, 'data_filter'):
+                tar.extractall(support_dir, filter='data')
+            else:
+                tar.extractall(support_dir)
         except tarfile.ExtractError as ex:
             print('ERROR: failed to unpack the archive', ex)
             cleanup(support_dir)

--- a/support/install-share.py
+++ b/support/install-share.py
@@ -80,7 +80,7 @@ def main():
                 tar.extractall(support_dir, filter='data')
             else:
                 tar.extractall(support_dir)
-        except tarfile.ExtractError as ex:
+        except tarfile.TarError as ex:
             print('ERROR: failed to unpack the archive', ex)
             cleanup(support_dir)
             sys.exit(1)


### PR DESCRIPTION
`tarfile.extractall()` without an explicit filter emits a `DeprecationWarning` on Python 3.12/3.13 during `make install`, and Python 3.14 already defaults to the `'data'` filter (PEP 706). Request the `'data'` filter explicitly where available, using the feature check documented in the `tarfile` docs (`hasattr(tarfile, 'data_filter')`, present also in the security backports to older 3.x releases); Python versions without extraction filters keep the current behavior unchanged.

The support package extracts cleanly under the `'data'` filter — it is the behavior already applied by default on Python 3.14 installs today (verified with an end-to-end `make install` on Python 3.14).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014nNMVbAuffaPPQuYdLZgD1