### PR TITLE
scripts: make retdec-archive-decompiler.py work with the native decompiler

### DIFF
--- a/scripts/retdec-archive-decompiler.py
+++ b/scripts/retdec-archive-decompiler.py
@@ -47,12 +47,17 @@ def parse_args(args):
                         action='store_true',
                         help="list")
 
-    parser.add_argument("--",
-                        nargs='+',
-                        dest="arg_list",
-                        help="args passed to the decompiler")
+    # argparse consumes the first '--' as the positional-arguments
+    # separator, so the decompiler arguments have to be split off
+    # manually before parsing.
+    decompiler_args = []
+    if '--' in args:
+        split_at = args.index('--')
+        args, decompiler_args = args[:split_at], args[split_at + 1:]
 
-    return parser.parse_args(args)
+    parsed = parser.parse_args(args)
+    parsed.arg_list = decompiler_args
+    return parsed
 
 
 class ArchiveDecompiler:
@@ -172,7 +177,7 @@ class ArchiveDecompiler:
         print('Running `%s' % DECOMPILER, end='')
 
         if self.decompiler_args:
-            print(' '.join(self.decompiler_args), end='')
+            print(' ' + ' '.join(self.decompiler_args), end='')
 
         print('` over %d files with timeout %d s. (run `kill %d ` to terminate this script)...' % (
             self.file_count, self.timeout, os.getpid()), file=sys.stderr)
@@ -186,14 +191,13 @@ class ArchiveDecompiler:
 
             # Do not escape!
             arg_list = [
-                sys.executable,
                 DECOMPILER,
                 '--ar-index=' + str(i),
                 '-o', self.library_path + '.file_' + str(file_index) + '.c',
                 self.library_path,
             ]
             if self.decompiler_args:
-                arg_list.append(self.decompiler_args)
+                arg_list.extend(self.decompiler_args)
             output, rc, timeouted = CmdRunner.run_cmd(
                 arg_list,
                 timeout=self.timeout,


### PR DESCRIPTION
`retdec-archive-decompiler.py` has been broken in two independent ways since `retdec-decompiler` became a native binary in v5.0:

1. **Every decompilation fails.** The per-member command is built as `[sys.executable, DECOMPILER, ...]`, i.e. it asks Python to interpret an ELF/PE executable, so every archive member ends in `[FAIL]`. The decompiler is now run directly. (Windows stays portable: `_WindowsProcess` in `retdec-utils.py` prepends the interpreter only for `*.py` scripts.)

2. **The advertised `--` pass-through never worked.** `argparse` consumes the first `--` as the positional separator, so `retdec-archive-decompiler.py file.a -- --backend-no-opts` died with `error: unrecognized arguments`. The argument list is now split at the first `--` manually and the bogus `add_argument("--")` entry is removed. Also `extend()` instead of `append()` so the forwarded arguments become separate argv entries, and a missing space in the `Running ...` log line is added.

## Testing

On a two-object `ar` archive with a stub `retdec-decompiler` recording its argv:

* `--list`, `--plain`, and `--json` list both members correctly,
* the decompile loop invokes the decompiler once per member as `retdec-decompiler --ar-index=N -o <archive>.file_M.c <archive> --backend-no-opts` and reports `[OK]`,
* `python3 -m py_compile` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014nNMVbAuffaPPQuYdLZgD1