### PR TITLE
Fix x86 MOV r64 memory reload width

### DIFF
--- a/src/capstone2llvmir/x86/x86.cpp
+++ b/src/capstone2llvmir/x86/x86.cpp
@@ -2521,18 +2521,26 @@ void Capstone2LlvmIrTranslatorX86_impl::translateMov(cs_insn* i, cs_x86* xi, llv
 {
 	EXPECT_IS_BINARY(i, xi, irb);
 
-	op1 = loadOp(xi->operands[1], irb);
+	auto src = xi->operands[1];
 	switch (i->id)
 	{
 		case X86_INS_MOV:
 		case X86_INS_MOVABS:
+			if ((xi->operands[0].type == X86_OP_REG || xi->operands[0].type == X86_OP_MEM)
+					&& (src.type == X86_OP_REG || src.type == X86_OP_MEM))
+			{
+				src.size = xi->operands[0].size;
+			}
+			op1 = loadOp(src, irb);
 			storeOp(xi->operands[0], op1, irb, eOpConv::ZEXT_TRUNC_OR_BITCAST);
 			break;
 		case X86_INS_MOVSX:
 		case X86_INS_MOVSXD:
+			op1 = loadOp(src, irb);
 			storeOp(xi->operands[0], op1, irb, eOpConv::SEXT_TRUNC_OR_BITCAST);
 			break;
 		case X86_INS_MOVZX:
+			op1 = loadOp(src, irb);
 			storeOp(xi->operands[0], op1, irb, eOpConv::ZEXT_TRUNC_OR_BITCAST);
 			break;
 		default:

--- a/tests/capstone2llvmir/x86_tests.cpp
+++ b/tests/capstone2llvmir/x86_tests.cpp
@@ -3313,6 +3313,28 @@ TEST_P(Capstone2LlvmIrTranslatorX86Tests, X86_INS_MOV_reg64_reg64)
 	EXPECT_NO_VALUE_CALLED();
 }
 
+TEST_P(Capstone2LlvmIrTranslatorX86Tests, X86_INS_MOV_reg64_mem64)
+{
+	ONLY_MODE_64;
+
+	setRegisters({
+		{X86_REG_RBP, 0x2000},
+	});
+	setMemory({
+		{0x1e58, 0x00007fff89abcdef_qw},
+	});
+
+	emulate("mov rbx, [rbp - 0x1a8]");
+
+	EXPECT_JUST_REGISTERS_LOADED({X86_REG_RBP});
+	EXPECT_JUST_REGISTERS_STORED({
+		{X86_REG_RBX, 0x00007fff89abcdef},
+	});
+	EXPECT_JUST_MEMORY_LOADED({0x1e58});
+	EXPECT_NO_MEMORY_STORED();
+	EXPECT_NO_VALUE_CALLED();
+}
+
 TEST_P(Capstone2LlvmIrTranslatorX86Tests, X86_INS_MOV_from_ds_addr_space_1)
 {
 	SKIP_MODE_16;


### PR DESCRIPTION
## Summary

Fixes #1249.

This patch keeps ordinary x86 `MOV`/`MOVABS` register and memory operands at
the destination operand width before loading the source. `MOVSX`, `MOVSXD`, and
`MOVZX` keep their existing unequal-width behavior.

ShadowGT found a case in sqlite's `balance` function where:

```asm
0x9658b: mov rbx, [rbp-0x1a8]
```

was represented downstream as a sign-extended low-i32 value and then used as a
pointer. For a normal REX.W `MOV r64, m64`, the loaded value must preserve all
64 bits.

## Test Coverage

Added a `capstone2llvmir` x86 regression test for:

```asm
mov rbx, [rbp - 0x1a8]
```

with a non-zero high-32-bit memory value.

## Local Validation

Ran:

```sh
git diff --check
```

I did not run the full RetDec test suite locally; this PR is intended to let the
official CI validate the patch.
